### PR TITLE
Load app using baseUrl `/web-client` (resolves #9)

### DIFF
--- a/.github/workflows/deploy-static-main.yml
+++ b/.github/workflows/deploy-static-main.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install Dependencies
         run: cd OwnTube.tv/ && npm install
       - name: Build Web App
-        run: cd OwnTube.tv/ && npx expo export
+        run: cd OwnTube.tv/ && npx expo export --platform web
       - name: Setup Pages
         uses: actions/configure-pages@v4
       - name: Upload artifact

--- a/OwnTube.tv/app.json
+++ b/OwnTube.tv/app.json
@@ -14,6 +14,9 @@
     "assetBundlePatterns": [
       "**/*"
     ],
+    "experiments": {
+      "baseUrl": "/web-client"
+    },
     "ios": {
       "supportsTablet": true
     },

--- a/OwnTube.tv/package.json
+++ b/OwnTube.tv/package.json
@@ -2,6 +2,7 @@
   "name": "owntube.tv",
   "version": "1.0.0",
   "main": "node_modules/expo/AppEntry.js",
+  "homepage": "https://owntube-tv.github.io/web-client/",
   "scripts": {
     "start": "expo start",
     "android": "expo start --android",


### PR DESCRIPTION
The page cannot load as the JavaScript bundle from the Expo build is referenced from the root path, `...thub.io/_expo/static/js/...`, but GitHub Pages serves it from a sub-path as `...thub.io/web-client/_expo/static/js/...`. This config change tells Expo to add the appropriate base path on export for web.

See Expo docs on the topic here, https://docs.expo.dev/more/expo-cli/#hosting-with-sub-paths

## Illustration

Proof that it works, from https://mblomdahl.github.io/web-client/:

<img width="742" alt="image" src="https://github.com/OwnTube-tv/web-client/assets/786326/796a9cff-d3a8-46d8-8cc3-bbeb619d0f0f">
