### PR TITLE
Add service for the PeerTube API, related to #10

### DIFF
--- a/OwnTube.tv/lib/peertubeVideosApi.test.ts
+++ b/OwnTube.tv/lib/peertubeVideosApi.test.ts
@@ -1,0 +1,81 @@
+import { PeertubeVideosApi } from "./peertubeVideosApi";
+
+describe("peertubeVideosApi", () => {
+  it("should return a list of videos, maximum 15 to default", async () => {
+    const peertubeVideosApi = new PeertubeVideosApi("peertube2.cpy.re");
+    const videos = await peertubeVideosApi.getVideos();
+
+    expect(videos).toBeDefined();
+    expect(videos.length).toBe(15);
+  });
+
+  it("should return a list of videos, limited to maximum 5 when specified", async () => {
+    const peertubeVideosApi = new PeertubeVideosApi("peertube2.cpy.re");
+    const videos = await peertubeVideosApi.getVideos(5);
+
+    expect(videos).toBeDefined();
+    expect(videos.length).toBe(5);
+  });
+
+  it("should return a list of videos, fetching maximum 3 per request when specified", async () => {
+    // This should call the PeerTube API with a request for 3 videos, then the next 3, and then 1 last video (flip debugLogging to true to see the requests in the console)
+    const peertubeVideosApi = new PeertubeVideosApi("peertube2.cpy.re", 3, false);
+    const videos = await peertubeVideosApi.getVideos(7);
+
+    expect(videos).toBeDefined();
+    expect(videos.length).toBe(7);
+  });
+
+  it("should return a list of videos, but not more than the total available videos", async () => {
+    const peertubeVideosApi = new PeertubeVideosApi("peertube2.cpy.re");
+    const totalVideos = await peertubeVideosApi.getTotalVideos();
+
+    peertubeVideosApi.maxChunkSize = Math.floor(totalVideos / 2) - 1;
+    // peertubeVideosApi.debugLogging = true;
+    let videos = await peertubeVideosApi.getVideos(totalVideos + 1);
+    // peertubeVideosApi.debugLogging = false;
+    expect(videos).toBeDefined();
+    expect(videos.length).toBe(totalVideos);
+
+    peertubeVideosApi.maxChunkSize = totalVideos + 5;
+    videos = await peertubeVideosApi.getVideos(totalVideos + 1);
+    expect(videos).toBeDefined();
+    expect(videos.length).toBe(totalVideos);
+  });
+
+  it("should return a list of videos, each with the properties indicated by the typing", async () => {
+    const peertubeVideosApi = new PeertubeVideosApi("peertube2.cpy.re");
+    const totalVideos = await peertubeVideosApi.getTotalVideos();
+    const videos = await peertubeVideosApi.getVideos(totalVideos);
+
+    expect(videos).toBeDefined();
+    expect(videos.length).toBe(totalVideos);
+    videos.forEach((video) => {
+      expect(new Set(Object.keys(video))).toEqual(new Set(["id", "name", "category", "description", "thumbnailPath"]));
+      expect(Number.isInteger(video.id)).toBe(true);
+      expect(typeof video.name).toBe("string");
+      if (video.category.id) {
+        expect(video.category).toMatchObject({ id: expect.any(Number), label: expect.any(String) });
+      } else {
+        expect(video.category).toMatchObject({ id: null, label: expect.any(String) });
+      }
+      if (video.description) {
+        expect(typeof video.description).toBe("string");
+      } else {
+        expect(video.description).toBeNull();
+      }
+      expect(typeof video.thumbnailPath).toBe("string");
+    });
+  });
+
+  it("should return a list of videos, each with a unique id", async () => {
+    const peertubeVideosApi = new PeertubeVideosApi("peertube2.cpy.re");
+    const totalVideos = await peertubeVideosApi.getTotalVideos();
+    const videos = await peertubeVideosApi.getVideos(totalVideos);
+
+    expect(videos).toBeDefined();
+    expect(videos.length).toBe(totalVideos);
+    const idSet = new Set(videos.map((video) => video.id));
+    expect(idSet.size).toBe(totalVideos);
+  });
+});

--- a/OwnTube.tv/lib/peertubeVideosApi.ts
+++ b/OwnTube.tv/lib/peertubeVideosApi.ts
@@ -1,0 +1,175 @@
+import axios, { AxiosInstance } from "axios";
+
+// Subset of the backend API query parameters, https://github.com/Chocobozzz/PeerTube/blob/develop/packages/models/src/search/videos-common-query.model.ts#L41
+interface GetVideosQueryParams {
+  start?: number;
+  count?: number;
+  sort?: string;
+  nsfw?: "true" | "false" | "both";
+  isLive?: boolean;
+  isLocal?: boolean;
+  hasHLSFiles?: boolean;
+  skipCount?: boolean;
+}
+
+// Subset of a video object from the PeerTube backend API, https://github.com/Chocobozzz/PeerTube/blob/develop/server/core/models/video/video.ts#L460
+interface GetVideosVideo {
+  id: number;
+  name: string;
+  category: { id: number | null; label: string };
+  description: string | null;
+  thumbnailPath: string;
+}
+
+/**
+ * Get videos from the PeerTube backend `/api/v1/videos` API
+ *
+ * @description https://docs.joinpeertube.org/api-rest-reference.html#tag/Video/operation/getVideos
+ */
+export class PeertubeVideosApi {
+  constructor(peertubeHost: string, maxChunkSize: number = 100, debugLogging: boolean = false) {
+    this.createAxiosInstance(peertubeHost);
+    this.maxChunkSize = maxChunkSize;
+    this.debugLogging = debugLogging;
+  }
+
+  debugLogging: boolean = false;
+
+  private _maxChunkSize!: number;
+  set maxChunkSize(value: number) {
+    if (!(value > 0 && value <= 100)) {
+      throw new Error("The maximum number of videos to fetch in a single request is 100");
+    }
+    this._maxChunkSize = value;
+  }
+  get maxChunkSize(): number {
+    return this._maxChunkSize;
+  }
+
+  // Common query parameters for fetching videos that are classified as "local", "non-live", and "Safe-For-Work"
+  private readonly commonQueryParams: GetVideosQueryParams = {
+    start: 0,
+    count: 15,
+    sort: "createdAt",
+    nsfw: "false",
+    isLocal: true,
+    isLive: false,
+    hasHLSFiles: true,
+    skipCount: false,
+  };
+
+  // Our Axios instance, https://axios-http.com/docs/instance
+  private instance!: AxiosInstance;
+
+  /**
+   * Create the Axios instance with our base URL, app identifier, and request/response interceptors
+   *
+   * @param peertubeHost - The PeerTube instance host
+   */
+  private createAxiosInstance(peertubeHost: string): void {
+    const baseURL = `https://${peertubeHost}/api/v1/`;
+    this.instance = axios.create({
+      baseURL: baseURL,
+      headers: {
+        "Content-Type": "application/json",
+        "User-Agent": "OwnTube.tv/1.0.0 (https://app.owntube.tv)",
+      },
+    });
+
+    this.instance.interceptors.request.use((config) => {
+      if (this.debugLogging) {
+        console.debug(`Requesting '${baseURL}${config.url}' with '${JSON.stringify(config.params)}'`);
+      }
+      return config;
+    });
+    this.instance.interceptors.response.use((response) => {
+      if (this.debugLogging) {
+        console.debug(
+          `Received response with status ${response.status} and data '${JSON.stringify(response.data).substring(0, 255)}...'`,
+        );
+      }
+      return response;
+    });
+  }
+
+  /**
+   * Get total number of "local", "non-live", and "Safe-For-Work" videos from the PeerTube instance
+   *
+   * @returns The total number of videos
+   */
+  async getTotalVideos(): Promise<number> {
+    try {
+      const response = await this.instance.get("videos", { params: { ...this.commonQueryParams, count: 0 } });
+      return response.data.total as number;
+    } catch (error: unknown) {
+      throw new Error(`Failed to fetch total number of videos from PeerTube API: ${(error as Error).message}`);
+    }
+  }
+
+  /**
+   * Get "local", "non-live", and "Safe-For-Work" videos from the PeerTube instance
+   *
+   * @param [limit=15] - The maximum number of videos to fetch
+   * @returns A list of videos, with a lot of additional details from the API removed
+   */
+  async getVideos(limit: number = 15): Promise<GetVideosVideo[]> {
+    let rawVideos: Required<GetVideosVideo>[] = [];
+    if (limit <= this.maxChunkSize) {
+      try {
+        rawVideos = (await this.instance.get("videos", { params: { ...this.commonQueryParams, count: limit } })).data
+          .data as Required<GetVideosVideo>[];
+      } catch (error: unknown) {
+        throw new Error(`Failed to fetch videos from PeerTube API: ${(error as Error).message}`);
+      }
+    } else {
+      let rawTotal = -1;
+      let offset = 0;
+      while (rawVideos.length < limit) {
+        let fetchCount = this.maxChunkSize;
+        const maxTotalToBeExceeded = rawTotal !== -1 && offset + this.maxChunkSize > rawTotal;
+        if (maxTotalToBeExceeded) {
+          fetchCount = rawTotal - offset;
+          if (this.debugLogging) {
+            console.debug(
+              `We would exceed the total available ${rawTotal} videos with chunk size ${this.maxChunkSize}, so fetching only ${fetchCount} videos to reach the total`,
+            );
+          }
+        }
+        const maxLimitToBeExceeded = rawVideos.length + fetchCount > limit;
+        if (maxLimitToBeExceeded) {
+          fetchCount = limit - offset;
+          if (this.debugLogging) {
+            console.debug(
+              `We would exceed max limit of ${limit} videos, so fetching only ${fetchCount} additional videos to reach the limit`,
+            );
+          }
+        }
+        try {
+          const response = await this.instance.get("videos", {
+            params: { ...this.commonQueryParams, count: fetchCount, start: offset },
+          });
+          rawTotal = response.data.total as number;
+          if (rawTotal < limit) {
+            limit = rawTotal;
+          }
+          rawVideos = rawVideos.concat(response.data.data as Required<GetVideosVideo>[]);
+        } catch (error: unknown) {
+          throw new Error(`Failed to fetch videos from PeerTube API: ${(error as Error).message}`);
+        }
+        offset += fetchCount;
+      }
+    }
+
+    const videos = rawVideos.map((video) => {
+      return {
+        id: video.id,
+        name: video.name,
+        category: video.category,
+        description: video.description,
+        thumbnailPath: video.thumbnailPath,
+      };
+    });
+
+    return videos;
+  }
+}

--- a/OwnTube.tv/package-lock.json
+++ b/OwnTube.tv/package-lock.json
@@ -13,6 +13,7 @@
         "@react-native-async-storage/async-storage": "^1.23.1",
         "@react-navigation/native": "^6.1.17",
         "@react-navigation/native-stack": "^6.9.26",
+        "axios": "^1.6.7",
         "expo": "~50.0.6",
         "expo-status-bar": "~1.11.1",
         "react": "18.2.0",
@@ -8216,6 +8217,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/axios": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+      "dependencies": {
+        "follow-redirects": "^1.15.4",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/babel-core": {
       "version": "7.0.0-bridge.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
@@ -10981,6 +11005,25 @@
       "integrity": "sha512-HVzoK3r6Vsg+lKvlIZzaWNBVai+FXTX1wdYhz/wVlH13tb/gOdLXmlTqy6odmTBhT5UoWUbq0k8263Qhr9d88w==",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
       }
     },
     "node_modules/fontfaceobserver": {
@@ -16886,6 +16929,11 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/pump": {
       "version": "3.0.0",

--- a/OwnTube.tv/package.json
+++ b/OwnTube.tv/package.json
@@ -16,6 +16,7 @@
     "@react-native-async-storage/async-storage": "^1.23.1",
     "@react-navigation/native": "^6.1.17",
     "@react-navigation/native-stack": "^6.9.26",
+    "axios": "^1.6.7",
     "expo": "~50.0.6",
     "expo-status-bar": "~1.11.1",
     "react": "18.2.0",


### PR DESCRIPTION
This service will be used to interact with the PeerTube backend API. It will be used to reliably retrieve videos when needed; at the moment, its functionality is limited to ...

1. restricting the subset of videos returned to those classified as "local", "non-live", and "Safe-For-Work"
2. limiting the number of videos returned to the requested number of videos, and
3. handling pagination transparently (as the API only returns a maximum of 100 videos on each request)

In the future, this service will be extended to include more functionality, such as ...

1. handling rate limits enforced by the backend
2. dealing with unexpected 4xx and 5xx errors gracefully
3. support for offline mode (i.e. when the backend is unreachable)
4. retrieving individual video details for playback
5. long polling for new/changed videos, and
6. efficient caching (e.g. using IndexedDB) to reduce the number of unnecessary requests

Ping @OGTor & @ar9708 & @tryklick, FYI!

----

(*Note:* As an exercise, feel free to see if you can improve upon the `PeertubeVideosApi` service to make it more readable and understandable, and still passing all tests.)