### PR TITLE
add video screen with video view (#8)

### DIFF
--- a/OwnTube.tv/.eslintrc.json
+++ b/OwnTube.tv/.eslintrc.json
@@ -19,7 +19,8 @@
   "plugins": ["@typescript-eslint", "react", "react-native"],
   "rules": {
     "react-native/no-raw-text": ["error", { "skip": ["Typography"] }],
-    "react/prop-types": "off"
+    "react/prop-types": "off",
+    "react-native/no-inline-styles": "off"
   },
   "settings": {
     "react": {

--- a/OwnTube.tv/components/VideoControlsOverlay/VideoControlsOverlay.tsx
+++ b/OwnTube.tv/components/VideoControlsOverlay/VideoControlsOverlay.tsx
@@ -1,0 +1,117 @@
+import { PropsWithChildren, useMemo } from "react";
+import { Dimensions, Pressable, StyleSheet, View } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { useTheme } from "@react-navigation/native";
+import { ScrubBar } from "./components/ScrubBar";
+
+interface VideoControlsOverlayProps {
+  isVisible: boolean;
+  onOverlayPress: () => void;
+  isPlaying?: boolean;
+  handlePlayPause: () => void;
+  handleRW: () => void;
+  handleFF: () => void;
+  percentageAvailable: number;
+  percentagePosition: number;
+  toggleMute: () => void;
+  isMute?: boolean;
+  shouldReplay?: boolean;
+  handleReplay: () => void;
+}
+
+export const VideoControlsOverlay = ({
+  children,
+  isVisible,
+  onOverlayPress,
+  isPlaying,
+  handlePlayPause,
+  handleRW,
+  handleFF,
+  percentageAvailable,
+  percentagePosition,
+  toggleMute,
+  isMute = false,
+  shouldReplay,
+  handleReplay,
+}: PropsWithChildren<VideoControlsOverlayProps>) => {
+  const { colors } = useTheme();
+
+  const buttonScale = useMemo(() => {
+    const { width, height } = Dimensions.get("window");
+    const isHorizontal = width > height;
+
+    return isHorizontal ? 1 : 0.5;
+  }, []);
+
+  const centralIconName = useMemo(() => {
+    return isPlaying ? "pause" : shouldReplay ? "reload" : "play";
+  }, [isPlaying, shouldReplay]);
+
+  return (
+    <Pressable style={styles.overlay} onPress={onOverlayPress}>
+      {isVisible ? (
+        <View style={styles.contentContainer}>
+          <View style={styles.topControlsContainer}>
+            <Pressable onPress={toggleMute}>
+              <Ionicons name={`volume-${isMute ? "mute" : "high"}`} size={48 * buttonScale} color={colors.primary} />
+            </Pressable>
+          </View>
+          <View style={styles.playbackControlsContainer}>
+            <View style={{ flexDirection: "row", gap: 48 * buttonScale }}>
+              <Pressable onPress={handleRW}>
+                <Ionicons name={"play-back"} size={96 * buttonScale} color={colors.primary} />
+              </Pressable>
+              <Pressable onPress={shouldReplay ? handleReplay : handlePlayPause}>
+                <Ionicons name={centralIconName} size={96 * buttonScale} color={colors.primary} />
+              </Pressable>
+              <Pressable onPress={handleFF}>
+                <Ionicons name={"play-forward"} size={96 * buttonScale} color={colors.primary} />
+              </Pressable>
+            </View>
+          </View>
+          <View style={styles.bottomControlsContainer}>
+            <ScrubBar percentageAvailable={percentageAvailable} percentagePosition={percentagePosition} />
+          </View>
+        </View>
+      ) : null}
+      {children}
+    </Pressable>
+  );
+};
+
+const styles = StyleSheet.create({
+  bottomControlsContainer: {
+    alignItems: "center",
+    bottom: 0,
+    height: "20%",
+    justifyContent: "center",
+    left: 0,
+    position: "absolute",
+    width: "100%",
+  },
+  contentContainer: { flex: 1, height: "100%", left: 0, position: "absolute", top: 0, width: "100%", zIndex: 1 },
+  overlay: {
+    alignSelf: "center",
+    maxHeight: "100%",
+    maxWidth: "100%",
+  },
+  playbackControlsContainer: {
+    alignItems: "center",
+    flex: 1,
+    height: "100%",
+    justifyContent: "center",
+    width: "100%",
+  },
+  topControlsContainer: {
+    alignItems: "center",
+    flexDirection: "row",
+    height: "20%",
+    justifyContent: "flex-end",
+    left: 0,
+    paddingRight: "5%",
+    position: "absolute",
+    top: 0,
+    width: "100%",
+    zIndex: 1,
+  },
+});

--- a/OwnTube.tv/components/VideoControlsOverlay/components/ScrubBar.tsx
+++ b/OwnTube.tv/components/VideoControlsOverlay/components/ScrubBar.tsx
@@ -1,0 +1,66 @@
+import { StyleSheet, View } from "react-native";
+import { useTheme } from "@react-navigation/native";
+
+interface ScrubBarProps {
+  percentageAvailable: number;
+  percentagePosition: number;
+}
+
+export const ScrubBar = ({ percentageAvailable, percentagePosition }: ScrubBarProps) => {
+  const { colors } = useTheme();
+
+  return (
+    <View
+      style={[
+        styles.scrubBarContainer,
+        {
+          backgroundColor: colors.background,
+          borderColor: colors.background,
+        },
+      ]}
+    >
+      <View
+        style={[
+          styles.percentageAvailableBar,
+          {
+            backgroundColor: colors.border,
+            width: `${percentageAvailable}%`,
+          },
+        ]}
+      />
+      <View
+        style={[
+          styles.percentagePositionBar,
+          {
+            backgroundColor: colors.primary,
+            width: `${percentagePosition}%`,
+          },
+        ]}
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  percentageAvailableBar: {
+    height: 3,
+    left: 0,
+    position: "absolute",
+    top: 1,
+    zIndex: 1,
+  },
+  percentagePositionBar: {
+    height: 3,
+    left: 0,
+    position: "absolute",
+    top: 1,
+    zIndex: 2,
+  },
+  scrubBarContainer: {
+    borderLeftWidth: 1,
+    borderRightWidth: 1,
+    flexDirection: "row",
+    height: 5,
+    width: "80%",
+  },
+});

--- a/OwnTube.tv/components/VideoControlsOverlay/index.ts
+++ b/OwnTube.tv/components/VideoControlsOverlay/index.ts
@@ -1,0 +1,1 @@
+export * from "./VideoControlsOverlay";

--- a/OwnTube.tv/components/VideoThumbnail.tsx
+++ b/OwnTube.tv/components/VideoThumbnail.tsx
@@ -1,15 +1,19 @@
 import { View, Image, StyleSheet, TouchableOpacity } from "react-native";
 import { getThumbnailDimensions } from "../utils";
 import { useAppConfigContext } from "../contexts";
-import type { Video } from "../types";
+import { ROUTES, Video } from "../types";
 import { Typography } from "./Typography";
-import { useTheme } from "@react-navigation/native";
+import { useNavigation, useTheme } from "@react-navigation/native";
+import { FC } from "react";
+import { RootStackParams } from "../navigation";
+import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 
 interface VideoThumbnailProps {
   video: Video;
 }
 
-export const VideoThumbnail: React.FC<VideoThumbnailProps> = ({ video }) => {
+export const VideoThumbnail: FC<VideoThumbnailProps> = ({ video }) => {
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParams>>();
   const { source } = useAppConfigContext();
 
   const imageUrl = video.thumbnailUrl || `${source}/default-thumbnail.jpg`;
@@ -19,7 +23,7 @@ export const VideoThumbnail: React.FC<VideoThumbnailProps> = ({ video }) => {
   return (
     <TouchableOpacity
       style={[styles.videoThumbnailContainer, { height, width }, { backgroundColor: colors.card }]}
-      onPress={() => console.log("Video Pressed", video.name)}
+      onPress={() => navigation.navigate(ROUTES.VIDEO)}
     >
       <Image source={{ uri: imageUrl }} style={styles.videoImage} />
       <View style={styles.textContainer}>

--- a/OwnTube.tv/components/VideoView.tsx
+++ b/OwnTube.tv/components/VideoView.tsx
@@ -1,0 +1,95 @@
+import { AVPlaybackStatus, AVPlaybackStatusSuccess, ResizeMode, Video } from "expo-av";
+import { useMemo, useRef, useState } from "react";
+import { Platform, View } from "react-native";
+import { VideoControlsOverlay } from "./VideoControlsOverlay";
+
+const hlsUri =
+  "https://tube.extinctionrebellion.fr/static/streaming-playlists/hls/8803fdd3-4ac9-49d0-8dcf-ff1586e9e458/1663f4f5-bb3d-44ec-8a21-6195e6407ba8-master.m3u8";
+
+const mp4Uri = "https://tube.extinctionrebellion.fr/download/videos/8803fdd3-4ac9-49d0-8dcf-ff1586e9e458-720.mp4";
+
+export const VideoView = () => {
+  const videoRef = useRef<Video>(null);
+  const isWeb = Platform.OS === "web";
+  const [isControlsVisible, setIsControlsVisible] = useState(false);
+  const [playbackStatus, setPlaybackStatus] = useState<AVPlaybackStatusSuccess | null>(null);
+
+  const toggleControls = () => {
+    setIsControlsVisible((prev) => !prev);
+  };
+
+  const handlePlayPause = () => {
+    videoRef.current?.[playbackStatus?.isPlaying ? "pauseAsync" : "playAsync"]();
+  };
+
+  const handlePlaybackStatusUpdate = (status: AVPlaybackStatus) => {
+    if (status.isLoaded) {
+      setPlaybackStatus(status);
+    } else if (status.error) {
+      console.error(status.error);
+    }
+  };
+
+  const handleRW = () => {
+    videoRef.current?.setPositionAsync((playbackStatus?.positionMillis ?? 0) - 10_000);
+  };
+
+  const handleFF = () => {
+    videoRef.current?.setPositionAsync((playbackStatus?.positionMillis ?? 0) + 10_000);
+  };
+
+  const toggleMute = () => {
+    videoRef.current?.setIsMutedAsync(!playbackStatus?.isMuted);
+  };
+
+  const { percentageAvailable, percentagePosition } = useMemo(() => {
+    const { durationMillis = 1, positionMillis = 1, playableDurationMillis = 1 } = playbackStatus || {};
+
+    if (!playbackStatus) {
+      return { percentageAvailable: 0, percentagePosition: 0 };
+    }
+
+    return {
+      percentageAvailable: (playableDurationMillis / playableDurationMillis) * 100,
+      percentagePosition: (positionMillis / durationMillis) * 100,
+    };
+  }, [playbackStatus]);
+
+  const handleReplay = () => {
+    videoRef.current?.playFromPositionAsync(0);
+  };
+
+  return (
+    <View
+      style={{
+        flex: 1,
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      <VideoControlsOverlay
+        handlePlayPause={handlePlayPause}
+        isPlaying={playbackStatus?.isPlaying}
+        isVisible={isControlsVisible}
+        onOverlayPress={toggleControls}
+        handleRW={handleRW}
+        handleFF={handleFF}
+        percentagePosition={percentagePosition}
+        percentageAvailable={percentageAvailable}
+        toggleMute={toggleMute}
+        isMute={playbackStatus?.isMuted}
+        shouldReplay={playbackStatus?.didJustFinish}
+        handleReplay={handleReplay}
+      >
+        <Video
+          shouldPlay
+          resizeMode={ResizeMode.CONTAIN}
+          ref={videoRef}
+          source={{ uri: isWeb ? mp4Uri : hlsUri }}
+          onPlaybackStatusUpdate={handlePlaybackStatusUpdate}
+          videoStyle={{ position: "relative" }}
+        />
+      </VideoControlsOverlay>
+    </View>
+  );
+};

--- a/OwnTube.tv/components/VideosByCategory.tsx
+++ b/OwnTube.tv/components/VideosByCategory.tsx
@@ -1,16 +1,16 @@
 import { View, StyleSheet } from "react-native";
 import { CategoryScroll, Typography, VideoThumbnail } from "./";
 import type { VideoCategory } from "../types";
+import { FC } from "react";
 
 interface VideosByCategoryProps {
   category: VideoCategory;
 }
 
-export const VideosByCategory: React.FC<VideosByCategoryProps> = ({ category }) => {
+export const VideosByCategory: FC<VideosByCategoryProps> = ({ category }) => {
   return (
     <View style={styles.container}>
       <Typography style={styles.categoryTitle}>{category.label}</Typography>
-
       <CategoryScroll>
         {category.videos.map((video) => (
           <VideoThumbnail key={video.id} video={video} />

--- a/OwnTube.tv/components/index.ts
+++ b/OwnTube.tv/components/index.ts
@@ -6,3 +6,4 @@ export * from "./shared";
 export * from "./VideosByCategory";
 export * from "./CategoryScroll";
 export * from "./VideoThumbnail";
+export * from "./VideoView";

--- a/OwnTube.tv/navigation/index.tsx
+++ b/OwnTube.tv/navigation/index.tsx
@@ -3,7 +3,7 @@ import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { useColorSchemeContext } from "../contexts";
 import { Pressable } from "react-native";
 import { Feather } from "@expo/vector-icons";
-import { HomeScreen, SettingsScreen } from "../screens";
+import { HomeScreen, SettingsScreen, VideoScreen } from "../screens";
 import { ROUTES } from "../types";
 
 const Stack = createNativeStackNavigator();
@@ -27,8 +27,15 @@ export const Navigation = () => {
             ),
           })}
         />
-        <Stack.Screen name={ROUTES.SETTINGS} component={SettingsScreen} />
+        <Stack.Screen options={{ title: "Settings" }} name={ROUTES.SETTINGS} component={SettingsScreen} />
+        <Stack.Screen options={{ title: "Video" }} name={ROUTES.VIDEO} component={VideoScreen} />
       </Stack.Navigator>
     </NavigationContainer>
   );
+};
+
+export type RootStackParams = {
+  [ROUTES.HOME]: undefined;
+  [ROUTES.SETTINGS]: undefined;
+  [ROUTES.VIDEO]: undefined;
 };

--- a/OwnTube.tv/package-lock.json
+++ b/OwnTube.tv/package-lock.json
@@ -14,6 +14,7 @@
         "@react-navigation/native": "^6.1.17",
         "@react-navigation/native-stack": "^6.9.26",
         "expo": "~50.0.6",
+        "expo-av": "~13.10.6",
         "expo-status-bar": "~1.11.1",
         "react": "18.2.0",
         "react-dom": "18.2.0",
@@ -10566,6 +10567,14 @@
         "expo-file-system": "~16.0.0",
         "invariant": "^2.2.4",
         "md5-file": "^3.2.3"
+      }
+    },
+    "node_modules/expo-av": {
+      "version": "13.10.6",
+      "resolved": "https://registry.npmjs.org/expo-av/-/expo-av-13.10.6.tgz",
+      "integrity": "sha512-h3c1fg5yhWnP0RIGO+fhgPx6cmh4B4lnKdXR2i69aC3vs5D5Cu+JlzBon1gLIu6eUo2IVfC0RjSLpfQbcJ4doQ==",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-constants": {

--- a/OwnTube.tv/package.json
+++ b/OwnTube.tv/package.json
@@ -24,7 +24,8 @@
     "react-native": "0.73.4",
     "react-native-safe-area-context": "^4.10.1",
     "react-native-screens": "^3.31.1",
-    "react-native-web": "~0.19.6"
+    "react-native-web": "~0.19.6",
+    "expo-av": "~13.10.6"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/OwnTube.tv/screens/VideoScreen/index.tsx
+++ b/OwnTube.tv/screens/VideoScreen/index.tsx
@@ -1,0 +1,5 @@
+import { VideoView } from "../../components";
+
+export const VideoScreen = () => {
+  return <VideoView />;
+};

--- a/OwnTube.tv/screens/index.ts
+++ b/OwnTube.tv/screens/index.ts
@@ -1,2 +1,3 @@
 export * from "./HomeScreen";
 export * from "./SettingsScreen";
+export * from "./VideoScreen";

--- a/OwnTube.tv/types.ts
+++ b/OwnTube.tv/types.ts
@@ -10,9 +10,9 @@ export enum STORAGE {
 }
 
 export enum ROUTES {
-  HOME = "Home",
-  SETTINGS = "Settings",
-  PROFILE = "Profile",
+  HOME = "home",
+  SETTINGS = "settings",
+  VIDEO = "video",
 }
 
 export type Theme = {


### PR DESCRIPTION
## 🚀 Description

See updated changes at https://mykhailodanilenko.github.io/web-client/

this PR adds a basic video player with controls to the app. for now it uses a hardcoded video url for every link. quality is pre-set to 720p for web, the app is not yet configured for mobile but if yes with current changes it would use HLS - on desktop hls is natively supported only on Safari.

## 📄 Motivation and Context

https://github.com/OwnTube-tv/web-client/issues/8

## 🧪 How Has This Been Tested?

tested on web desktop + mobile. the mp4 streaming works and I believe the lib is handling the download so that it doesn't load the whole video, HLS works wonderfully on Safari and Android Chrome, even chooses appropriate quality automatically.

## 📷 Screenshots (if appropriate)

<img width="1440" alt="image" src="https://github.com/OwnTube-tv/web-client/assets/53569595/51511b9c-8547-434f-8493-00a909279c81">


## 📦 Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist (copied from README)

- [x] Squash your changes into a single clear and thoroughly descriptive commit, split changes into multiple commits only when it contributes to readability
- [x] Reference the GitHub issue that you are contributing on in your commit title or body
- [x] Sign your commits, as this is required by the automated GitHub PR checks
- [x] Ensure that the changes adhere to the project code style and formatting rules by running `npx eslint .` and `npx prettier --check ../` from the `./OwnTube.tv/` directory (without errors/warnings)
- [x] Include links and illustrations in your pull request to make it easy to review
- [x] Request a review by @ar9708, @OGTor, @tryklick and @mblomdahl
