### PR TITLE
Add support for HLS on web

### DIFF
--- a/OwnTube.tv/api/peertubeVideosApi.ts
+++ b/OwnTube.tv/api/peertubeVideosApi.ts
@@ -42,7 +42,6 @@ export class PeertubeVideosApi {
     nsfw: "false",
     isLocal: true,
     isLive: false,
-    hasWebVideoFiles: true,
     skipCount: false,
   };
 

--- a/OwnTube.tv/api/tests/peertubeVideosApi.test.ts
+++ b/OwnTube.tv/api/tests/peertubeVideosApi.test.ts
@@ -21,7 +21,7 @@ describe("peertubeVideosApi", () => {
     const peertubeVideosApi = new PeertubeVideosApi();
     const total = await peertubeVideosApi.getTotalVideos("http://peertube2.cpy.re");
 
-    expect(total).toBe(4);
+    expect(total).toBe(27);
   });
 
   it("should return a list of videos, but not more than the total available videos", async () => {

--- a/OwnTube.tv/app/+html.tsx
+++ b/OwnTube.tv/app/+html.tsx
@@ -1,0 +1,20 @@
+/* eslint-disable react-native/no-raw-text */
+import type { PropsWithChildren } from "react";
+
+export default function Root({ children }: PropsWithChildren) {
+  return (
+    <html lang="en">
+      <head>
+        <meta charSet="utf-8" />
+        <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+        <style id="expo-reset">{"html, body { height: 100%; } #root { display: flex; height: 100%; flex: 1; }"}</style>
+        <script src="https://vjs.zencdn.net/8.10.0/video.min.js"></script>
+      </head>
+      <body>
+        <noscript>You need to enable JavaScript to run this app.</noscript>
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/OwnTube.tv/app/_layout.tsx
+++ b/OwnTube.tv/app/_layout.tsx
@@ -1,5 +1,5 @@
 import { Stack, useNavigation } from "expo-router";
-import { Pressable } from "react-native";
+import { Platform, Pressable } from "react-native";
 import { ROUTES } from "../types";
 import { Feather } from "@expo/vector-icons";
 import { DarkTheme, DefaultTheme, NavigationProp, ThemeProvider } from "@react-navigation/native";
@@ -36,10 +36,12 @@ const RootStack = () => {
 const queryClient = new QueryClient();
 
 export default function RootLayout() {
+  const isWeb = Platform.OS === "web";
+
   return (
     <QueryClientProvider client={queryClient}>
       <AppConfigContextProvider>
-        <ReactQueryDevtools initialIsOpen={false} />
+        {isWeb && <ReactQueryDevtools initialIsOpen={false} />}
         <ColorSchemeContextProvider>
           <RootStack />
         </ColorSchemeContextProvider>

--- a/OwnTube.tv/components/Loader.tsx
+++ b/OwnTube.tv/components/Loader.tsx
@@ -1,0 +1,13 @@
+import { ActivityIndicator, StyleSheet, View } from "react-native";
+
+export const Loader = () => {
+  return (
+    <View style={styles.container}>
+      <ActivityIndicator size="large" />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { alignItems: "center", flex: 1, height: "100%", justifyContent: "center", width: "100%" },
+});

--- a/OwnTube.tv/components/VideoControlsOverlay/VideoControlsOverlay.tsx
+++ b/OwnTube.tv/components/VideoControlsOverlay/VideoControlsOverlay.tsx
@@ -117,9 +117,12 @@ const styles = StyleSheet.create({
   },
   contentContainer: { flex: 1, height: "100%", left: 0, position: "absolute", top: 0, width: "100%", zIndex: 1 },
   overlay: {
+    alignItems: "center",
     alignSelf: "center",
-    maxHeight: "100%",
-    maxWidth: "100%",
+    display: "flex",
+    height: "100%",
+    justifyContent: "center",
+    width: "100%",
   },
   playbackControlsContainer: {
     alignItems: "center",

--- a/OwnTube.tv/components/VideoList.tsx
+++ b/OwnTube.tv/components/VideoList.tsx
@@ -1,5 +1,5 @@
-import { View, StyleSheet, ActivityIndicator } from "react-native";
-import { ErrorMessage, Typography, VideosByCategory } from "./";
+import { View, StyleSheet } from "react-native";
+import { ErrorMessage, Loader, Typography, VideosByCategory } from "./";
 import { useGetVideosQuery } from "../api";
 import { GetVideosVideo } from "../api/peertubeVideosApi";
 
@@ -24,11 +24,7 @@ export const VideoList = () => {
   }
 
   if (isFetching) {
-    return (
-      <View style={{ flex: 1 }}>
-        <ActivityIndicator size="large" />
-      </View>
-    );
+    return <Loader />;
   }
 
   if (data?.videos.length === 0) {

--- a/OwnTube.tv/components/VideoView/VideoView.tsx
+++ b/OwnTube.tv/components/VideoView/VideoView.tsx
@@ -1,14 +1,15 @@
 import { AVPlaybackStatus, AVPlaybackStatusSuccess, ResizeMode, Video } from "expo-av";
 import { useRef, useState } from "react";
-import { StyleSheet, View } from "react-native";
-import { VideoControlsOverlay } from "./VideoControlsOverlay";
+import { View } from "react-native";
+import { VideoControlsOverlay } from "../VideoControlsOverlay";
+import { styles } from "./styles";
 
-interface VideoViewProps {
+export interface VideoViewProps {
   uri: string;
   testID: string;
 }
 
-export const VideoView = ({ uri, testID }: VideoViewProps) => {
+const VideoView = ({ uri, testID }: VideoViewProps) => {
   const videoRef = useRef<Video>(null);
   const [isControlsVisible, setIsControlsVisible] = useState(false);
   const [playbackStatus, setPlaybackStatus] = useState<AVPlaybackStatusSuccess | null>(null);
@@ -81,10 +82,4 @@ export const VideoView = ({ uri, testID }: VideoViewProps) => {
   );
 };
 
-const styles = StyleSheet.create({
-  container: {
-    alignItems: "center",
-    flex: 1,
-    justifyContent: "center",
-  },
-});
+export default VideoView;

--- a/OwnTube.tv/components/VideoView/VideoView.web.tsx
+++ b/OwnTube.tv/components/VideoView/VideoView.web.tsx
@@ -1,0 +1,163 @@
+import { useEffect, useRef, useState } from "react";
+import { View } from "react-native";
+import { VideoControlsOverlay } from "../VideoControlsOverlay";
+import Player from "video.js/dist/types/player";
+import { VideoViewProps } from "./VideoView";
+import { styles } from "./styles";
+import "./styles.web.css";
+import videojs from "video.js";
+
+declare const window: {
+  videojs: typeof videojs;
+} & Window;
+
+const VideoView = ({ uri, testID }: VideoViewProps) => {
+  const { videojs } = window;
+  const videoRef = useRef<HTMLDivElement>(null);
+  const playerRef = useRef<Player | null>(null);
+  const [isControlsVisible, setIsControlsVisible] = useState(false);
+  const [playbackStatus, setPlaybackStatus] = useState({
+    didJustFinish: false,
+    isMuted: false,
+    isPlaying: true,
+    position: 0,
+    duration: 1,
+    playableDuration: 0,
+  });
+
+  const updatePlaybackStatus = (updatedStatus: Partial<typeof playbackStatus>) => {
+    setPlaybackStatus((prev) => ({ ...prev, ...updatedStatus }));
+  };
+
+  const toggleControls = () => {
+    setIsControlsVisible((prev) => !prev);
+  };
+
+  const handlePlayPause = () => {
+    if (playerRef.current?.paused()) {
+      playerRef.current?.play();
+    } else {
+      playerRef.current?.pause();
+    }
+  };
+
+  const handleRW = () => {
+    playerRef.current?.currentTime(playbackStatus.position / 1000 - 10);
+  };
+
+  const handleFF = () => {
+    playerRef.current?.currentTime(playbackStatus.position / 1000 + 10);
+  };
+
+  const toggleMute = () => {
+    const newValue = !playerRef.current?.muted();
+    playerRef.current?.muted(newValue);
+    updatePlaybackStatus({ isMuted: newValue });
+  };
+
+  const handleReplay = () => {
+    playerRef.current?.currentTime(0);
+  };
+
+  const handleJumpTo = (position: number) => {
+    playerRef.current?.tech().setCurrentTime(position / 1000);
+  };
+
+  const options = {
+    autoplay: true,
+    controls: false,
+    html5: {
+      vhs: {
+        overrideNative: true,
+      },
+    },
+    sources: [
+      {
+        src: uri,
+      },
+    ],
+    children: ["MediaLoader"],
+  };
+
+  const onReady = (player: Player) => {
+    playerRef.current = player;
+
+    player.on("loadedmetadata", () => {
+      updatePlaybackStatus({
+        duration: Math.floor(playerRef.current?.duration() ?? 0) * 1000,
+        playableDuration: playerRef.current?.bufferedEnd(),
+      });
+    });
+
+    player.on("play", () => {
+      updatePlaybackStatus({ isPlaying: true, didJustFinish: false });
+    });
+
+    player.on("pause", () => {
+      updatePlaybackStatus({ isPlaying: false });
+    });
+
+    player.on("timeupdate", () => {
+      updatePlaybackStatus({ position: Math.floor(playerRef.current?.currentTime() ?? 0) * 1000 });
+    });
+
+    player.on("ended", () => {
+      updatePlaybackStatus({ didJustFinish: true });
+    });
+  };
+
+  useEffect(() => {
+    if (!videojs) return;
+
+    if (!playerRef.current) {
+      const videoElement = document.createElement("video-js");
+
+      videoElement.classList.add("vjs-big-play-centered");
+      videoRef.current?.appendChild(videoElement);
+
+      const player = (playerRef.current = videojs(videoElement, options, () => {
+        onReady && onReady(player);
+      }));
+    } else {
+      const player = playerRef.current;
+
+      player.options(options);
+    }
+  }, [options, videojs]);
+
+  useEffect(() => {
+    const player = playerRef.current;
+
+    return () => {
+      if (player && !player.isDisposed()) {
+        player.dispose();
+        playerRef.current = null;
+      }
+    };
+  }, []);
+
+  return (
+    <View style={styles.container}>
+      <VideoControlsOverlay
+        handlePlayPause={handlePlayPause}
+        isPlaying={playbackStatus?.isPlaying}
+        isVisible={isControlsVisible}
+        onOverlayPress={toggleControls}
+        handleRW={handleRW}
+        handleFF={handleFF}
+        duration={playbackStatus?.duration}
+        availableDuration={playbackStatus?.playableDuration}
+        position={playbackStatus?.position}
+        toggleMute={toggleMute}
+        isMute={playbackStatus?.isMuted}
+        shouldReplay={playbackStatus?.didJustFinish}
+        handleReplay={handleReplay}
+        handleJumpTo={handleJumpTo}
+      >
+        <div style={{ position: "relative" }} ref={videoRef} data-testid={`${testID}-video-playback`} />
+      </VideoControlsOverlay>
+    </View>
+  );
+};
+
+export default VideoView;

--- a/OwnTube.tv/components/VideoView/index.ts
+++ b/OwnTube.tv/components/VideoView/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./VideoView";

--- a/OwnTube.tv/components/VideoView/styles.ts
+++ b/OwnTube.tv/components/VideoView/styles.ts
@@ -1,0 +1,9 @@
+import { StyleSheet } from "react-native";
+
+export const styles = StyleSheet.create({
+  container: {
+    alignItems: "center",
+    flex: 1,
+    justifyContent: "center",
+  },
+});

--- a/OwnTube.tv/components/VideoView/styles.web.css
+++ b/OwnTube.tv/components/VideoView/styles.web.css
@@ -1,0 +1,16 @@
+.video-js {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+}
+
+video {
+  width: 100vw;
+  max-width: 100%;
+  height: 100vh;
+  max-height: 100%;
+  object-fit: contain;
+  z-index: -1;
+}

--- a/OwnTube.tv/components/index.ts
+++ b/OwnTube.tv/components/index.ts
@@ -6,5 +6,6 @@ export * from "./shared";
 export * from "./VideosByCategory";
 export * from "./CategoryScroll";
 export * from "./VideoThumbnail";
-export * from "./VideoView";
+export * from "./VideoView/VideoView";
 export * from "./VideoControlsOverlay";
+export * from "./Loader";

--- a/OwnTube.tv/package-lock.json
+++ b/OwnTube.tv/package-lock.json
@@ -33,7 +33,8 @@
         "react-native-safe-area-context": "4.10.1",
         "react-native-screens": "3.31.1",
         "react-native-web": "~0.19.6",
-        "react-test-renderer": "18.2.0"
+        "react-test-renderer": "18.2.0",
+        "video.js": "^8.12.0"
       },
       "devDependencies": {
         "@babel/core": "^7.24.0",
@@ -10316,6 +10317,52 @@
         "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
       }
     },
+    "node_modules/@videojs/http-streaming": {
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-3.12.1.tgz",
+      "integrity": "sha512-rpB5AMt0QZ9bMXzwiWhynF2NLNnm5g2DZjPOFX6OoFqqXhbe2ngY2nqm9lLRhRVe22YeysQCmAlvBNwGuWFI8Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@videojs/vhs-utils": "4.0.0",
+        "aes-decrypter": "4.0.1",
+        "global": "^4.4.0",
+        "m3u8-parser": "^7.1.0",
+        "mpd-parser": "^1.3.0",
+        "mux.js": "7.0.3",
+        "video.js": "^7 || ^8"
+      },
+      "engines": {
+        "node": ">=8",
+        "npm": ">=5"
+      },
+      "peerDependencies": {
+        "video.js": "^8.11.0"
+      }
+    },
+    "node_modules/@videojs/vhs-utils": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-4.0.0.tgz",
+      "integrity": "sha512-xJp7Yd4jMLwje2vHCUmi8MOUU76nxiwII3z4Eg3Ucb+6rrkFVGosrXlMgGnaLjq724j3wzNElRZ71D/CKrTtxg==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "global": "^4.4.0",
+        "url-toolkit": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8",
+        "npm": ">=5"
+      }
+    },
+    "node_modules/@videojs/xhr": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@videojs/xhr/-/xhr-2.6.0.tgz",
+      "integrity": "sha512-7J361GiN1tXpm+gd0xz2QWr3xNWBE+rytvo8J3KuggFaLg+U37gZQ2BuPLcnkfGffy2e+ozY70RHC8jt7zjA6Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "global": "~4.4.0",
+        "is-function": "^1.0.1"
+      }
+    },
     "node_modules/@web3-storage/multipart-parser": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@web3-storage/multipart-parser/-/multipart-parser-1.0.0.tgz",
@@ -10399,6 +10446,31 @@
       "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/aes-decrypter": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/aes-decrypter/-/aes-decrypter-4.0.1.tgz",
+      "integrity": "sha512-H1nh/P9VZXUf17AA5NQfJML88CFjVBDuGkp5zDHa7oEhYN9TTpNLJknRY1ie0iSKWlDf6JRnJKaZVDSQdPy6Cg==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@videojs/vhs-utils": "^3.0.5",
+        "global": "^4.4.0",
+        "pkcs7": "^1.0.4"
+      }
+    },
+    "node_modules/aes-decrypter/node_modules/@videojs/vhs-utils": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-3.0.5.tgz",
+      "integrity": "sha512-PKVgdo8/GReqdx512F+ombhS+Bzogiofy1LgAj4tN8PfdBx3HSS7V5WfJotKTqtOWGwVfSWsrYN/t09/DSryrw==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "global": "^4.4.0",
+        "url-toolkit": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8",
+        "npm": ">=5"
       }
     },
     "node_modules/agent-base": {
@@ -12719,6 +12791,11 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dom-walk": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
+      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
+    },
     "node_modules/domexception": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
@@ -14763,6 +14840,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/global": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
+      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
+      "dependencies": {
+        "min-document": "^2.19.0",
+        "process": "^0.11.10"
+      }
+    },
     "node_modules/globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -15288,6 +15374,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/individual": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/individual/-/individual-2.0.0.tgz",
+      "integrity": "sha512-pWt8hBCqJsUWI/HtcfWod7+N9SgAqyPEaF7JQjwzjn5vGrpg6aQ5qeAFQ7dx//UH4J1O+7xqew+gCeeFt6xN/g=="
+    },
     "node_modules/infer-owner": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
@@ -15581,6 +15672,11 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/is-function": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
+      "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ=="
     },
     "node_modules/is-generator-fn": {
       "version": "2.1.0",
@@ -18621,6 +18717,11 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/keycode": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.0.tgz",
+      "integrity": "sha512-ps3I9jAdNtRpJrbBvQjpzyFbss/skHqzS+eu4RxKLaEAtFqkjZaB6TZMSivPbLxf4K7VI4SjR0P5mRCX5+Q25A=="
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -19221,6 +19322,30 @@
       "integrity": "sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA==",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/m3u8-parser": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/m3u8-parser/-/m3u8-parser-7.1.0.tgz",
+      "integrity": "sha512-7N+pk79EH4oLKPEYdgRXgAsKDyA/VCo0qCHlUwacttQA0WqsjZQYmNfywMvjlY9MpEBVZEt0jKFd73Kv15EBYQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@videojs/vhs-utils": "^3.0.5",
+        "global": "^4.4.0"
+      }
+    },
+    "node_modules/m3u8-parser/node_modules/@videojs/vhs-utils": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-3.0.5.tgz",
+      "integrity": "sha512-PKVgdo8/GReqdx512F+ombhS+Bzogiofy1LgAj4tN8PfdBx3HSS7V5WfJotKTqtOWGwVfSWsrYN/t09/DSryrw==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "global": "^4.4.0",
+        "url-toolkit": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8",
+        "npm": ">=5"
       }
     },
     "node_modules/magnet-uri": {
@@ -19906,6 +20031,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/min-document": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+      "integrity": "sha512-9Wy1B3m3f66bPPmU5hdA4DR4PB2OfDU/+GS3yAB7IQozE3tqXaVv2zOjgla7MEGSRv95+ILmOuvhLkOK6wJtCQ==",
+      "dependencies": {
+        "dom-walk": "^0.1.0"
+      }
+    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -20029,6 +20162,28 @@
         "node": "*"
       }
     },
+    "node_modules/mpd-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/mpd-parser/-/mpd-parser-1.3.0.tgz",
+      "integrity": "sha512-WgeIwxAqkmb9uTn4ClicXpEQYCEduDqRKfmUdp4X8vmghKfBNXZLYpREn9eqrDx/Tf5LhzRcJLSpi4ohfV742Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@videojs/vhs-utils": "^4.0.0",
+        "@xmldom/xmldom": "^0.8.3",
+        "global": "^4.4.0"
+      },
+      "bin": {
+        "mpd-to-m3u8-json": "bin/parse.js"
+      }
+    },
+    "node_modules/mpd-parser/node_modules/@xmldom/xmldom": {
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
+      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/mrmime": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-1.0.1.tgz",
@@ -20142,6 +20297,22 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/mux.js": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-7.0.3.tgz",
+      "integrity": "sha512-gzlzJVEGFYPtl2vvEiJneSWAWD4nfYRHD5XgxmB2gWvXraMPOYk+sxfvexmNfjQUFpmk6hwLR5C6iSFmuwCHdQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.11.2",
+        "global": "^4.4.0"
+      },
+      "bin": {
+        "muxjs-transmux": "bin/transmux.js"
+      },
+      "engines": {
+        "node": ">=8",
+        "npm": ">=5"
+      }
     },
     "node_modules/mv": {
       "version": "2.1.1",
@@ -20954,6 +21125,17 @@
         "node": ">= 6"
       }
     },
+    "node_modules/pkcs7": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/pkcs7/-/pkcs7-1.0.4.tgz",
+      "integrity": "sha512-afRERtHn54AlwaF2/+LFszyAANTCggGilmcmILUzEjvs3XgFZT+xE6+QWQcAGmu4xajy+Xtj7acLOPdx5/eXWQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5"
+      },
+      "bin": {
+        "pkcs7": "bin/cli.js"
+      }
+    },
     "node_modules/pkg-dir": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
@@ -21232,6 +21414,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/process-nextick-args": {
@@ -22216,6 +22406,14 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rust-result": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rust-result/-/rust-result-1.0.0.tgz",
+      "integrity": "sha512-6cJzSBU+J/RJCF063onnQf0cDUOHs9uZI1oroSGnHOph+CQTIJ5Pp2hK5kEQq1+7yE/EEWfulSNXAQ2jikPthA==",
+      "dependencies": {
+        "individual": "^2.0.0"
+      }
+    },
     "node_modules/safe-array-concat": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
@@ -22242,6 +22440,14 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/safe-json-parse": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/safe-json-parse/-/safe-json-parse-4.0.0.tgz",
+      "integrity": "sha512-RjZPPHugjK0TOzFrLZ8inw44s9bKox99/0AZW9o/BEQVrJfhI+fIHMErnPyRa89/yRXUUr93q+tiN6zhoVV4wQ==",
+      "dependencies": {
+        "rust-result": "^1.0.0"
+      }
     },
     "node_modules/safe-json-stringify": {
       "version": "1.2.0",
@@ -24030,6 +24236,11 @@
         "requires-port": "^1.0.0"
       }
     },
+    "node_modules/url-toolkit": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/url-toolkit/-/url-toolkit-2.2.5.tgz",
+      "integrity": "sha512-mtN6xk+Nac+oyJ/PrI7tzfmomRVNFIWKUbG8jdYFt52hxbiReFAXIjYskvu64/dvuW71IcB7lV8l0HvZMac6Jg=="
+    },
     "node_modules/use-latest-callback": {
       "version": "0.1.9",
       "resolved": "https://registry.npmjs.org/use-latest-callback/-/use-latest-callback-0.1.9.tgz",
@@ -24111,6 +24322,55 @@
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/video.js": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/video.js/-/video.js-8.12.0.tgz",
+      "integrity": "sha512-bLjfg3y09CAed1xZ4FujdTW7G9kgL0CJHaBnDKwBUgYuutijCutYPP5yQGCdN6VOi76uEuOpINwmTJSJia6zww==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@videojs/http-streaming": "3.12.1",
+        "@videojs/vhs-utils": "^4.0.0",
+        "@videojs/xhr": "2.6.0",
+        "aes-decrypter": "^4.0.1",
+        "global": "4.4.0",
+        "keycode": "2.2.0",
+        "m3u8-parser": "^7.1.0",
+        "mpd-parser": "^1.2.2",
+        "mux.js": "^7.0.1",
+        "safe-json-parse": "4.0.0",
+        "videojs-contrib-quality-levels": "4.1.0",
+        "videojs-font": "4.1.0",
+        "videojs-vtt.js": "0.15.5"
+      }
+    },
+    "node_modules/videojs-contrib-quality-levels": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/videojs-contrib-quality-levels/-/videojs-contrib-quality-levels-4.1.0.tgz",
+      "integrity": "sha512-TfrXJJg1Bv4t6TOCMEVMwF/CoS8iENYsWNKip8zfhB5kTcegiFYezEA0eHAJPU64ZC8NQbxQgOwAsYU8VXbOWA==",
+      "dependencies": {
+        "global": "^4.4.0"
+      },
+      "engines": {
+        "node": ">=16",
+        "npm": ">=8"
+      },
+      "peerDependencies": {
+        "video.js": "^8"
+      }
+    },
+    "node_modules/videojs-font": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/videojs-font/-/videojs-font-4.1.0.tgz",
+      "integrity": "sha512-X1LuPfLZPisPLrANIAKCknZbZu5obVM/ylfd1CN+SsCmPZQ3UMDPcvLTpPBJxcBuTpHQq2MO1QCFt7p8spnZ/w=="
+    },
+    "node_modules/videojs-vtt.js": {
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/videojs-vtt.js/-/videojs-vtt.js-0.15.5.tgz",
+      "integrity": "sha512-yZbBxvA7QMYn15Lr/ZfhhLPrNpI/RmCSCqgIff57GC2gIrV5YfyzLfLyZMj0NnZSAz8syB4N0nHXpZg9MyrMOQ==",
+      "dependencies": {
+        "global": "^4.3.1"
       }
     },
     "node_modules/vlq": {

--- a/OwnTube.tv/package.json
+++ b/OwnTube.tv/package.json
@@ -18,11 +18,11 @@
     "@react-native-async-storage/async-storage": "^1.23.1",
     "@react-navigation/native": "^6.1.17",
     "@react-navigation/native-stack": "^6.9.26",
-    "date-fns": "^3.6.0",
     "@tanstack/react-query": "^5.40.0",
     "@tanstack/react-query-devtools": "^5.40.0",
     "@testing-library/react-native": "^12.5.1",
     "axios": "^1.7.2",
+    "date-fns": "^3.6.0",
     "expo": "^51.0.8",
     "expo-av": "~14.0.5",
     "expo-constants": "~16.0.1",
@@ -33,11 +33,12 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-native": "0.74.1",
+    "react-native-gesture-handler": "~2.16.1",
     "react-native-safe-area-context": "4.10.1",
     "react-native-screens": "3.31.1",
     "react-native-web": "~0.19.6",
-    "react-native-gesture-handler": "~2.16.1",
-    "react-test-renderer": "18.2.0"
+    "react-test-renderer": "18.2.0",
+    "video.js": "^8.12.0"
   },
   "devDependencies": {
     "@babel/core": "^7.24.0",

--- a/OwnTube.tv/screens/VideoScreen/index.tsx
+++ b/OwnTube.tv/screens/VideoScreen/index.tsx
@@ -1,25 +1,36 @@
-import { VideoView } from "../../components";
+import VideoView from "../../components/VideoView";
 import { useLocalSearchParams } from "expo-router";
 import { RootStackParams } from "../../app/_layout";
 import { ROUTES } from "../../types";
 import { useGetVideoQuery } from "../../api";
 import { useMemo } from "react";
+import { Loader } from "../../components";
 
 export const VideoScreen = () => {
   const params = useLocalSearchParams<RootStackParams[ROUTES.VIDEO]>();
 
-  const { data } = useGetVideoQuery(params?.id);
+  const { data, isFetching } = useGetVideoQuery(params?.id);
 
   const uri = useMemo(() => {
-    if (!params?.id || !data?.files?.length) {
-      return null;
+    if (!params?.id || !data) {
+      return;
     }
 
-    const files = data.files.filter(({ resolution }) => resolution.id <= 1080);
+    if (data?.streamingPlaylists?.length) {
+      const hlsStream = data.streamingPlaylists[0];
+
+      return hlsStream.playlistUrl;
+    }
+
+    const files = data.files?.filter(({ resolution }) => resolution.id <= 1080);
 
     // temporarily choose the highest quality
-    return files[0].fileUrl;
+    return files?.[0].fileUrl;
   }, [params, data]);
+
+  if (isFetching) {
+    return <Loader />;
+  }
 
   if (!uri) {
     return null;


### PR DESCRIPTION
## 🚀 Description

https://mykhailodanilenko.github.io/web-client/ <- see deployed version here
This PR adds support for HLS playback on the web, utilizing the video.js library. iOS and Android will still use expo-av.

## 📄 Motivation and Context

#64

## 🧪 How Has This Been Tested?

chrome, firefox, safari - desktop + mobile

## 📦 Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist (copied from README)

- [x] Squash your changes into a single clear and thoroughly descriptive commit, split changes into multiple commits only when it contributes to readability
- [x] Reference the GitHub issue that you are contributing on in your commit title or body
- [x] Sign your commits, as this is required by the automated GitHub PR checks
- [x] Ensure that the changes adhere to the project code style and formatting rules by running `npx eslint .` and `npx prettier --check ../` from the `./OwnTube.tv/` directory (without errors/warnings)
- [x] Include links and illustrations in your pull request to make it easy to review
- [x] Request a review by @ar9708, @OGTor, @tryklick and @mblomdahl
