### PR TITLE
Add "resume watching" functionality

### DIFF
--- a/OwnTube.tv/app/_layout.tsx
+++ b/OwnTube.tv/app/_layout.tsx
@@ -77,7 +77,7 @@ export const unstable_settings = {
 export type RootStackParams = {
   [ROUTES.INDEX]: { backend: string };
   [ROUTES.SETTINGS]: { backend: string };
-  [ROUTES.VIDEO]: { backend: string; id: string };
+  [ROUTES.VIDEO]: { backend: string; id: string; timestamp?: string };
 };
 
 const styles = StyleSheet.create({

--- a/OwnTube.tv/components/ResumeWatching.tsx
+++ b/OwnTube.tv/components/ResumeWatching.tsx
@@ -1,0 +1,28 @@
+import { useViewHistory } from "../hooks";
+import { StyleSheet, View } from "react-native";
+import { Typography } from "./Typography";
+import { Spacer } from "./shared/Spacer";
+import { ViewHistoryListItem } from "./ViewHistoryListItem";
+
+export const ResumeWatching = () => {
+  const { viewHistory, isFetching } = useViewHistory();
+  const latestVideo = viewHistory?.[0];
+
+  if (!latestVideo || isFetching) {
+    return null;
+  }
+
+  return (
+    <View style={styles.container}>
+      <Spacer height={16} />
+      <Typography>Continue where you left off:</Typography>
+      <Spacer height={16} />
+      <ViewHistoryListItem video={latestVideo} />
+      <Spacer height={16} />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { paddingHorizontal: 16, width: "100%" },
+});

--- a/OwnTube.tv/components/VideoThumbnail.tsx
+++ b/OwnTube.tv/components/VideoThumbnail.tsx
@@ -12,7 +12,7 @@ import { ViewHistoryEntry } from "../hooks";
 interface VideoThumbnailProps {
   video: GetVideosVideo & Partial<ViewHistoryEntry>;
   backend?: string;
-  percentageWatched?: number;
+  timestamp?: number;
 }
 
 const defaultImagePaths = {
@@ -20,12 +20,14 @@ const defaultImagePaths = {
   light: require("./../assets/Logo400x400.png"),
 };
 
-export const VideoThumbnail: FC<VideoThumbnailProps> = ({ video, backend, percentageWatched }) => {
+export const VideoThumbnail: FC<VideoThumbnailProps> = ({ video, backend, timestamp }) => {
   const { scheme } = useColorSchemeContext();
 
   const imageSource = video.thumbnailPath ? { uri: video.thumbnailPath } : defaultImagePaths[scheme ?? "dark"];
   const { width, height } = getThumbnailDimensions();
   const { colors } = useTheme();
+
+  const percentageWatched = timestamp ? (timestamp / video.duration) * 100 : 0;
 
   if (!backend) {
     return null;
@@ -34,7 +36,7 @@ export const VideoThumbnail: FC<VideoThumbnailProps> = ({ video, backend, percen
   return (
     <Link
       style={[styles.videoThumbnailContainer, { height, width }, { backgroundColor: colors.card }]}
-      href={{ pathname: `/${ROUTES.VIDEO}`, params: { id: video.uuid, backend } }}
+      href={{ pathname: `/${ROUTES.VIDEO}`, params: { id: video.uuid, backend, timestamp } }}
     >
       <Image source={imageSource} style={styles.videoImage} />
       <View style={styles.textContainer}>

--- a/OwnTube.tv/components/VideoView/VideoView.tsx
+++ b/OwnTube.tv/components/VideoView/VideoView.tsx
@@ -9,9 +9,10 @@ export interface VideoViewProps {
   uri: string;
   testID: string;
   handleSetTimeStamp: (timestamp: number) => void;
+  timestamp?: string;
 }
 
-const VideoView = ({ uri, testID, handleSetTimeStamp }: VideoViewProps) => {
+const VideoView = ({ uri, testID, handleSetTimeStamp, timestamp }: VideoViewProps) => {
   const videoRef = useRef<Video>(null);
   const [isControlsVisible, setIsControlsVisible] = useState(false);
   const [playbackStatus, setPlaybackStatus] = useState<AVPlaybackStatusSuccess | null>(null);
@@ -26,12 +27,12 @@ const VideoView = ({ uri, testID, handleSetTimeStamp }: VideoViewProps) => {
   };
 
   const handlePlaybackStatusUpdate = (status: AVPlaybackStatus) => {
-    if (status.isLoaded) {
+    if (status?.isLoaded) {
       setPlaybackStatus(status);
       setPlayerImplementation(
         status.androidImplementation ? `Android ${status.androidImplementation}` : "iOS Native player",
       );
-    } else if (status.error) {
+    } else if (status?.error) {
       console.error(status.error);
     }
   };
@@ -66,6 +67,10 @@ const VideoView = ({ uri, testID, handleSetTimeStamp }: VideoViewProps) => {
       handleSetTimeStamp(positionFormatted);
     }
   }, [playbackStatus?.positionMillis]);
+
+  useEffect(() => {
+    videoRef.current?.setPositionAsync(Number(timestamp) * 1000);
+  }, [timestamp]);
 
   return (
     <View style={styles.container}>

--- a/OwnTube.tv/components/VideoView/VideoView.web.tsx
+++ b/OwnTube.tv/components/VideoView/VideoView.web.tsx
@@ -12,7 +12,7 @@ declare const window: {
   videojs: typeof videojs;
 } & Window;
 
-const VideoView = ({ uri, testID, handleSetTimeStamp }: VideoViewProps) => {
+const VideoView = ({ uri, testID, handleSetTimeStamp, timestamp }: VideoViewProps) => {
   const { videojs } = window;
   const videoRef = useRef<HTMLDivElement>(null);
   const playerRef = useRef<Player | null>(null);
@@ -101,7 +101,10 @@ const VideoView = ({ uri, testID, handleSetTimeStamp }: VideoViewProps) => {
     });
 
     player.on("timeupdate", () => {
-      updatePlaybackStatus({ position: Math.floor(playerRef.current?.currentTime() ?? 0) * 1000 });
+      updatePlaybackStatus({
+        position: Math.floor(playerRef.current?.currentTime() ?? 0) * 1000,
+        didJustFinish: false,
+      });
     });
 
     player.on("ended", () => {
@@ -139,6 +142,12 @@ const VideoView = ({ uri, testID, handleSetTimeStamp }: VideoViewProps) => {
       }
     };
   }, []);
+
+  useEffect(() => {
+    if (timestamp) {
+      playerRef.current?.currentTime(Number(timestamp));
+    }
+  }, [timestamp]);
 
   useEffect(() => {
     const { position } = playbackStatus;

--- a/OwnTube.tv/components/VideosByCategory.tsx
+++ b/OwnTube.tv/components/VideosByCategory.tsx
@@ -5,6 +5,7 @@ import { GetVideosVideo } from "../api/peertubeVideosApi";
 import { useLocalSearchParams } from "expo-router";
 import { RootStackParams } from "../app/_layout";
 import { ROUTES } from "../types";
+import { useViewHistory } from "../hooks";
 
 interface VideosByCategoryProps {
   title: string;
@@ -13,14 +14,17 @@ interface VideosByCategoryProps {
 
 export const VideosByCategory: FC<VideosByCategoryProps> = ({ title, videos }) => {
   const { backend } = useLocalSearchParams<RootStackParams[ROUTES.INDEX]>();
+  const { getViewHistoryEntryByUuid } = useViewHistory();
 
   return (
     <View style={styles.container}>
       <Typography style={styles.categoryTitle}>{title}</Typography>
       <CategoryScroll>
-        {videos.map((video) => (
-          <VideoThumbnail key={video.uuid} video={video} backend={backend} />
-        ))}
+        {videos.map((video) => {
+          const { timestamp } = getViewHistoryEntryByUuid(video.uuid) || {};
+
+          return <VideoThumbnail key={video.uuid} video={video} backend={backend} timestamp={timestamp} />;
+        })}
       </CategoryScroll>
     </View>
   );

--- a/OwnTube.tv/components/ViewHistoryListItem.tsx
+++ b/OwnTube.tv/components/ViewHistoryListItem.tsx
@@ -12,12 +12,7 @@ interface ViewHistoryListItemProps {
 export const ViewHistoryListItem = ({ video }: ViewHistoryListItemProps) => {
   return (
     <View style={styles.container}>
-      <VideoThumbnail
-        percentageWatched={(video.timestamp / video.duration) * 100}
-        video={video}
-        backend={video.backend}
-        key={video.uuid}
-      />
+      <VideoThumbnail video={video} backend={video.backend} key={video.uuid} timestamp={video.timestamp} />
       <View>
         <Typography>Last playback timestamp: {getHumanReadableDuration(video.timestamp * 1000)}</Typography>
         <Typography>Video duration: {getHumanReadableDuration(video.duration * 1000)}</Typography>

--- a/OwnTube.tv/components/index.ts
+++ b/OwnTube.tv/components/index.ts
@@ -10,3 +10,4 @@ export * from "./VideoView/VideoView";
 export * from "./VideoControlsOverlay";
 export * from "./Loader";
 export * from "./DeviceCapabilitiesModal";
+export * from "./ResumeWatching";

--- a/OwnTube.tv/screens/HomeScreen/index.tsx
+++ b/OwnTube.tv/screens/HomeScreen/index.tsx
@@ -1,4 +1,4 @@
-import { Header, VideoList } from "../../components";
+import { Header, ResumeWatching, VideoList } from "../../components";
 import { Screen } from "../../layouts";
 import { styles } from "./styles";
 import { useTheme } from "@react-navigation/native";
@@ -18,6 +18,7 @@ export const HomeScreen = () => {
     <Screen style={{ ...styles.container, backgroundColor: theme.colors.background }}>
       <Image source={logoSource} width={160} height={160} />
       <Header />
+      <ResumeWatching />
       <VideoList />
     </Screen>
   );

--- a/OwnTube.tv/screens/VideoScreen/index.tsx
+++ b/OwnTube.tv/screens/VideoScreen/index.tsx
@@ -63,5 +63,12 @@ export const VideoScreen = () => {
     return null;
   }
 
-  return <VideoView handleSetTimeStamp={handleSetTimeStamp} testID={`${params.id}-video-view`} uri={uri} />;
+  return (
+    <VideoView
+      timestamp={params?.timestamp}
+      handleSetTimeStamp={handleSetTimeStamp}
+      testID={`${params.id}-video-view`}
+      uri={uri}
+    />
+  );
 };


### PR DESCRIPTION
## 🚀 Description

this PR adds "resume watching" functionality as described in #69. the latest history entry is put on the homepage and all videos are now opened from latest watched position. also, you can specify the time from when you want to start watching with the optional "timestamp" url param (time is in seconds).
See deployed at https://mykhailodanilenko.github.io/web-client/

## 📄 Motivation and Context

#69

## 🧪 How Has This Been Tested?

web version

## 📦 Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist (copied from README)

- [x] Squash your changes into a single clear and thoroughly descriptive commit, split changes into multiple commits only when it contributes to readability
- [x] Reference the GitHub issue that you are contributing on in your commit title or body
- [x] Sign your commits, as this is required by the automated GitHub PR checks
- [x] Ensure that the changes adhere to the project code style and formatting rules by running `npx eslint .` and `npx prettier --check ../` from the `./OwnTube.tv/` directory (without errors/warnings)
- [x] Include links and illustrations in your pull request to make it easy to review
- [x] Request a review by @ar9708, @OGTor, @tryklick and @mblomdahl
