### PR TITLE
Select custom instances from Sepia

### DIFF
--- a/OwnTube.tv/api/instanceSearchApi.ts
+++ b/OwnTube.tv/api/instanceSearchApi.ts
@@ -1,0 +1,45 @@
+import axios, { AxiosInstance } from "axios";
+import { PeertubeInstance } from "./models";
+
+export class InstanceSearchApi {
+  private instance!: AxiosInstance;
+  constructor() {
+    this.createAxiosInstance();
+  }
+
+  /**
+   * Create the Axios instance with request/response interceptors
+   */
+  private createAxiosInstance(): void {
+    this.instance = axios.create({
+      headers: {
+        "Access-Control-Allow-Origin": "*",
+        "Content-Type": "application/json",
+      },
+    });
+  }
+
+  // Common query parameters for fetching videos that are classified as "local", "non-live", and "Safe-For-Work"
+  private readonly commonQueryParams = {
+    start: 0,
+    count: 1000,
+    sort: "createdAt",
+  };
+
+  /**
+   * Get up to 1000 instances
+   */
+  async searchInstances(): Promise<{ data: Array<PeertubeInstance> }> {
+    try {
+      const response = await this.instance.get("instances", {
+        params: this.commonQueryParams,
+        baseURL: "https://instances.joinpeertube.org/api/v1",
+      });
+      return response.data;
+    } catch (error: unknown) {
+      throw new Error(`Failed to fetch instances: ${(error as Error).message}`);
+    }
+  }
+}
+
+export const InstanceSearchServiceImpl = new InstanceSearchApi();

--- a/OwnTube.tv/api/models.ts
+++ b/OwnTube.tv/api/models.ts
@@ -1,0 +1,35 @@
+// Subset of a video object from the PeerTube backend API, https://github.com/Chocobozzz/PeerTube/blob/develop/server/core/models/video/video.ts#L460
+import { VideoModel } from "@peertube/peertube-types/server/core/models/video/video";
+
+export type GetVideosVideo = Pick<VideoModel, "uuid" | "name" | "description" | "duration"> & {
+  thumbnailPath: string;
+  category: { id: number | null; label: string };
+};
+
+export type PeertubeInstance = {
+  id: number;
+  host: string;
+  name: string;
+  shortDescription: string;
+  version: string;
+  signupAllowed: boolean;
+  signupRequiresApproval: boolean;
+  userVideoQuota: number;
+  liveEnabled: boolean;
+  categories: number[];
+  languages: string[];
+  autoBlacklistUserVideosEnabled: boolean;
+  defaultNSFWPolicy: "do_not_list" | "display" | "blur";
+  isNSFW: boolean;
+  avatars: Array<{ width: number; url: string }>;
+  banners: Array<{ width: number; url: string }>;
+  totalUsers: number;
+  totalVideos: number;
+  totalLocalVideos: number;
+  totalInstanceFollowers: number;
+  totalInstanceFollowing: number;
+  supportsIPv6: boolean;
+  country: string;
+  health: number;
+  createdAt: number;
+};

--- a/OwnTube.tv/api/peertubeVideosApi.ts
+++ b/OwnTube.tv/api/peertubeVideosApi.ts
@@ -1,13 +1,7 @@
 import axios, { AxiosInstance } from "axios";
 import { VideosCommonQuery } from "@peertube/peertube-types";
-import { VideoModel } from "@peertube/peertube-types/server/core/models/video/video";
 import { Video } from "@peertube/peertube-types/peertube-models/videos/video.model";
-
-// Subset of a video object from the PeerTube backend API, https://github.com/Chocobozzz/PeerTube/blob/develop/server/core/models/video/video.ts#L460
-export type GetVideosVideo = Pick<VideoModel, "uuid" | "name" | "description" | "duration"> & {
-  thumbnailPath: string;
-  category: { id: number | null; label: string };
-};
+import { GetVideosVideo } from "./models";
 
 /**
  * Get videos from the PeerTube backend `/api/v1/videos` API

--- a/OwnTube.tv/api/queries.ts
+++ b/OwnTube.tv/api/queries.ts
@@ -1,14 +1,17 @@
 import { useQuery } from "@tanstack/react-query";
-import { ApiServiceImpl, GetVideosVideo } from "./peertubeVideosApi";
+import { ApiServiceImpl } from "./peertubeVideosApi";
 import { SOURCES } from "../types";
 import { getLocalData } from "./helpers";
 import { Video } from "@peertube/peertube-types/peertube-models/videos/video.model";
 import { useLocalSearchParams } from "expo-router";
 import { RootStackParams } from "../app/_layout";
+import { InstanceSearchServiceImpl } from "./instanceSearchApi";
+import { GetVideosVideo } from "./models";
 
 export enum QUERY_KEYS {
   videos = "videos",
   video = "video",
+  instances = "instances",
 }
 
 export const useGetVideosQuery = <TResult = GetVideosVideo[]>({
@@ -51,5 +54,16 @@ export const useGetVideoQuery = <TResult = Video>(id?: string, select?: (data: V
     refetchOnWindowFocus: false,
     enabled: !!backend && !!id,
     select,
+  });
+};
+
+export const useGetInstancesQuery = () => {
+  return useQuery({
+    queryKey: [QUERY_KEYS.instances],
+    queryFn: async () => {
+      return await InstanceSearchServiceImpl.searchInstances();
+    },
+    refetchOnWindowFocus: false,
+    select: ({ data }) => data,
   });
 };

--- a/OwnTube.tv/colors.ts
+++ b/OwnTube.tv/colors.ts
@@ -3,4 +3,5 @@ export const colors = {
   ghostwhite: "#F8F8FF",
   gainsboro: "#DCDCDC",
   _50percentBlackTint: "rgba(0, 0, 0, 0.5)",
+  sepia: "#704214",
 };

--- a/OwnTube.tv/components/AppConfig.tsx
+++ b/OwnTube.tv/components/AppConfig.tsx
@@ -1,0 +1,35 @@
+import { DeviceCapabilities } from "./DeviceCapabilities";
+import { StyleSheet, Switch, View } from "react-native";
+import { Typography } from "./Typography";
+import { useAppConfigContext, useColorSchemeContext } from "../contexts";
+
+export const AppConfig = () => {
+  const { isDebugMode, setIsDebugMode } = useAppConfigContext();
+  const { scheme, toggleScheme } = useColorSchemeContext();
+
+  return (
+    <View style={styles.deviceInfoAndToggles}>
+      <DeviceCapabilities />
+      <View style={styles.togglesContainer}>
+        <View style={styles.option}>
+          <Typography>Debug logging</Typography>
+          <Switch value={isDebugMode} onValueChange={setIsDebugMode} />
+        </View>
+        <View style={styles.option}>
+          <Typography>Toggle Theme</Typography>
+          <Switch value={scheme === "light"} onValueChange={toggleScheme} />
+        </View>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  deviceInfoAndToggles: { flexDirection: "row", flexWrap: "wrap", gap: 16, width: "100%" },
+  option: {
+    alignItems: "center",
+    flexDirection: "row",
+    gap: 5,
+  },
+  togglesContainer: { flex: 1, minWidth: 200 },
+});

--- a/OwnTube.tv/components/ComboBoxInput.tsx
+++ b/OwnTube.tv/components/ComboBoxInput.tsx
@@ -1,0 +1,136 @@
+import { FlatList, Pressable, StyleSheet, TextInput, View } from "react-native";
+import { Typography } from "./Typography";
+import { useCallback, useMemo, useState } from "react";
+import { useTheme } from "@react-navigation/native";
+
+interface DropDownItem {
+  label: string;
+  value: string;
+}
+
+interface ComboBoxInputProps {
+  value?: string;
+  onChange: (value: string) => void;
+  data?: Array<DropDownItem>;
+  testID: string;
+}
+
+const LIST_ITEM_HEIGHT = 50;
+
+const DropdownItem = ({
+  onSelect,
+  item,
+  value,
+}: {
+  onSelect: (item: DropDownItem) => () => void;
+  item: DropDownItem;
+  value: string;
+}) => {
+  const [isHovered, setIsHovered] = useState(false);
+  const { colors } = useTheme();
+
+  return (
+    <Pressable
+      onHoverIn={() => setIsHovered(true)}
+      onHoverOut={() => setIsHovered(false)}
+      style={{
+        justifyContent: "center",
+        height: LIST_ITEM_HEIGHT,
+        backgroundColor: colors[isHovered ? "card" : "background"],
+      }}
+      onPress={onSelect(item)}
+    >
+      <Typography color={item.value === value ? colors.primary : undefined}>{item.label}</Typography>
+    </Pressable>
+  );
+};
+
+export const ComboBoxInput = ({ value = "", onChange, data = [], testID }: ComboBoxInputProps) => {
+  const { colors } = useTheme();
+  const [inputValue, setInputValue] = useState("");
+  const [isDropDownVisible, setIsDropDownVisible] = useState(false);
+
+  const onSelect = (item: { label: string; value: string }) => () => {
+    onChange(item.value);
+    setInputValue("");
+    setIsDropDownVisible(false);
+  };
+
+  const filteredList = useMemo(() => {
+    if (!inputValue) {
+      return data;
+    }
+
+    return data.filter(({ label }) => label.toLowerCase().includes(inputValue.toLowerCase()));
+  }, [data, inputValue]);
+
+  const initialScrollIndex = useMemo(() => {
+    if (value) {
+      const scrollTo = filteredList?.findIndex(({ value: itemValue }) => itemValue === value) || 0;
+
+      return scrollTo > 0 ? scrollTo : 0;
+    }
+
+    return 0;
+  }, [filteredList, value]);
+
+  const renderItem = useCallback(
+    ({ item }: { item: DropDownItem }) => <DropdownItem item={item} onSelect={onSelect} value={value} />,
+    [value, onSelect],
+  );
+
+  return (
+    <View testID={testID} accessible={false}>
+      <TextInput
+        placeholder="Search instances..."
+        placeholderTextColor={colors.text}
+        style={[{ color: colors.primary, backgroundColor: colors.card, borderColor: colors.primary }, styles.input]}
+        onFocus={() => setIsDropDownVisible(true)}
+        onBlur={() => {
+          setTimeout(() => {
+            setIsDropDownVisible(false);
+          }, 300);
+        }}
+        value={inputValue}
+        onChangeText={setInputValue}
+      />
+      {isDropDownVisible && (
+        <View style={[{ borderColor: colors.border }, styles.optionsContainer]}>
+          <FlatList
+            data={filteredList}
+            renderItem={renderItem}
+            extraData={filteredList?.length}
+            initialScrollIndex={initialScrollIndex}
+            keyExtractor={({ value }) => value}
+            getItemLayout={(_, index) => ({
+              length: LIST_ITEM_HEIGHT,
+              offset: LIST_ITEM_HEIGHT * index,
+              index,
+            })}
+            maxToRenderPerBatch={50}
+          />
+        </View>
+      )}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  input: {
+    borderRadius: 8,
+    borderWidth: 1,
+    height: 30,
+    width: 300,
+  },
+  optionsContainer: {
+    borderRadius: 8,
+    borderWidth: 1,
+    flex: 1,
+    height: 400,
+    padding: 8,
+    position: "absolute",
+    top: 30,
+    width: 500,
+    zIndex: 1,
+  },
+});

--- a/OwnTube.tv/components/SourceSelect.test.tsx
+++ b/OwnTube.tv/components/SourceSelect.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react-native";
+import { SourceSelect } from "./SourceSelect";
+
+jest.mock("../api", () => ({
+  ...jest.requireActual("../api"),
+  useGetInstancesQuery: () => ({
+    data: [
+      { id: "withLocalVids", totalLocalVideos: 100 },
+      { id: "withoutLocalVids", totalLocalVideos: 0 },
+    ],
+  }),
+}));
+
+jest.mock("./ComboBoxInput", () => ({
+  ComboBoxInput: "ComboBoxInput",
+}));
+
+describe("SourceSelect", () => {
+  it("should filter out 0-video instances", () => {
+    render(<SourceSelect />);
+    expect(screen.getByTestId("custom-instance-select").props.data.length).toBe(1);
+  });
+});

--- a/OwnTube.tv/components/SourceSelect.tsx
+++ b/OwnTube.tv/components/SourceSelect.tsx
@@ -1,18 +1,22 @@
-import { useCallback } from "react";
-import { StyleSheet, View } from "react-native";
+import { useCallback, useMemo } from "react";
+import { Linking, Pressable, StyleSheet, View } from "react-native";
 import { SOURCES, STORAGE } from "../types";
 import { Typography } from "./Typography";
 import { useTheme } from "@react-navigation/native";
-import { useLocalSearchParams, useRouter } from "expo-router";
+import { Link, useLocalSearchParams, useRouter } from "expo-router";
 import { writeToAsyncStorage } from "../utils";
 import { RootStackParams } from "../app/_layout";
+import { useGetInstancesQuery } from "../api";
+import { ComboBoxInput } from "./ComboBoxInput";
+import { Spacer } from "./shared/Spacer";
+import { colors } from "../colors";
 
 export const SourceSelect = () => {
   const { backend } = useLocalSearchParams<RootStackParams["settings"]>();
   const router = useRouter();
-  const { colors } = useTheme();
+  const theme = useTheme();
 
-  const handleSelectSource = (backend: string) => () => {
+  const handleSelectSource = (backend: string) => {
     router.setParams({ backend });
     writeToAsyncStorage(STORAGE.DATASOURCE, backend);
   };
@@ -22,8 +26,8 @@ export const SourceSelect = () => {
       <Typography
         key={item}
         style={styles.source}
-        color={item === backend ? colors.primary : undefined}
-        onPress={handleSelectSource(item)}
+        color={item === backend ? theme.colors.primary : undefined}
+        onPress={() => handleSelectSource(item)}
       >
         {item}
       </Typography>
@@ -31,11 +35,45 @@ export const SourceSelect = () => {
     [backend, handleSelectSource],
   );
 
+  const { data } = useGetInstancesQuery();
+
+  const availableInstances = useMemo(() => {
+    return data
+      ?.filter(({ totalLocalVideos }) => totalLocalVideos > 0)
+      .map(({ name, host, totalLocalVideos }) => ({
+        label: `${host} - ${name} (${totalLocalVideos})`,
+        value: host,
+      }));
+  }, [data]);
+
   return (
     <View style={styles.container}>
-      <Typography>Select source:</Typography>
+      {backend && (
+        <View style={{ flexDirection: "row" }}>
+          <Typography>Selected instance: </Typography>
+          <Pressable onPress={() => Linking.openURL(`https://${backend}/`)}>
+            <Typography color={theme.colors.primary}>{backend}</Typography>
+          </Pressable>
+        </View>
+      )}
+      <Spacer height={16} />
+      <Typography>Predefined instances:</Typography>
       {Object.values(SOURCES).map(renderItem)}
       {backend && backend in SOURCES && renderItem(backend)}
+      <Spacer height={16} />
+      <Typography>
+        <Link style={{ textDecorationLine: "underline", color: colors.sepia }} href={"https://sepiasearch.org/"}>
+          Sepia
+        </Link>{" "}
+        PeerTube instances:
+      </Typography>
+      <Spacer height={16} />
+      <ComboBoxInput
+        testID={"custom-instance-select"}
+        value={backend}
+        data={availableInstances}
+        onChange={handleSelectSource}
+      />
     </View>
   );
 };

--- a/OwnTube.tv/components/VideoList.tsx
+++ b/OwnTube.tv/components/VideoList.tsx
@@ -1,7 +1,7 @@
 import { View, StyleSheet } from "react-native";
 import { ErrorMessage, Loader, Typography, VideosByCategory } from "./";
 import { useGetVideosQuery } from "../api";
-import { GetVideosVideo } from "../api/peertubeVideosApi";
+import { GetVideosVideo } from "../api/models";
 
 type CategorizedVideos = Record<string, GetVideosVideo[]>;
 

--- a/OwnTube.tv/components/VideoThumbnail.tsx
+++ b/OwnTube.tv/components/VideoThumbnail.tsx
@@ -5,9 +5,9 @@ import { Typography } from "./Typography";
 import { useTheme } from "@react-navigation/native";
 import { FC } from "react";
 import { Link } from "expo-router";
-import { GetVideosVideo } from "../api/peertubeVideosApi";
 import { ROUTES } from "../types";
 import { ViewHistoryEntry } from "../hooks";
+import { GetVideosVideo } from "../api/models";
 
 interface VideoThumbnailProps {
   video: GetVideosVideo & Partial<ViewHistoryEntry>;

--- a/OwnTube.tv/components/VideosByCategory.tsx
+++ b/OwnTube.tv/components/VideosByCategory.tsx
@@ -1,11 +1,11 @@
 import { View, StyleSheet } from "react-native";
 import { CategoryScroll, Typography, VideoThumbnail } from "./";
 import { FC } from "react";
-import { GetVideosVideo } from "../api/peertubeVideosApi";
 import { useLocalSearchParams } from "expo-router";
 import { RootStackParams } from "../app/_layout";
 import { ROUTES } from "../types";
 import { useViewHistory } from "../hooks";
+import { GetVideosVideo } from "../api/models";
 
 interface VideosByCategoryProps {
   title: string;

--- a/OwnTube.tv/components/index.ts
+++ b/OwnTube.tv/components/index.ts
@@ -14,3 +14,5 @@ export * from "./BuildInfoToast";
 export * from "./ClickableHeaderText";
 export * from "./ResumeWatching";
 export * from "./ViewHistory";
+export * from "./ComboBoxInput";
+export * from "./AppConfig";

--- a/OwnTube.tv/hooks/useViewHistory.ts
+++ b/OwnTube.tv/hooks/useViewHistory.ts
@@ -1,8 +1,8 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { deleteFromAsyncStorage, multiGetFromAsyncStorage, readFromAsyncStorage, writeToAsyncStorage } from "../utils";
 import { STORAGE } from "../types";
-import { GetVideosVideo } from "../api/peertubeVideosApi";
 import type { DefaultError } from "@tanstack/query-core";
+import { GetVideosVideo } from "../api/models";
 
 export type ViewHistoryEntry = GetVideosVideo & {
   firstViewedAt?: number;

--- a/OwnTube.tv/screens/SettingsScreen/index.tsx
+++ b/OwnTube.tv/screens/SettingsScreen/index.tsx
@@ -1,32 +1,45 @@
-import { View, Switch } from "react-native";
-import { SourceSelect, Typography, ViewHistory, DeviceCapabilities } from "../../components";
-import { useAppConfigContext, useColorSchemeContext } from "../../contexts";
+import { View, Pressable } from "react-native";
+import { SourceSelect, Typography, ViewHistory, AppConfig } from "../../components";
 import { Screen } from "../../layouts";
 import { styles } from "./styles";
 import { useTheme } from "@react-navigation/native";
+import React, { useState } from "react";
+
+type SettingsTab = "history" | "instance" | "config";
+
+const tabsWithNames: Record<SettingsTab, string> = {
+  history: "History",
+  instance: "Instance",
+  config: "Config",
+};
 
 export const SettingsScreen = () => {
-  const { isDebugMode, setIsDebugMode } = useAppConfigContext();
-  const { scheme, toggleScheme } = useColorSchemeContext();
   const { colors } = useTheme();
+  const [tab, setTab] = useState<SettingsTab>("history");
+
+  const tabContent: Record<SettingsTab, React.JSX.Element> = {
+    history: <ViewHistory />,
+    instance: <SourceSelect />,
+    config: <AppConfig />,
+  };
 
   return (
     <Screen style={{ ...styles.container, backgroundColor: colors.background }}>
-      <View style={styles.deviceInfoAndToggles}>
-        <DeviceCapabilities />
-        <View style={styles.togglesContainer}>
-          <View style={styles.option}>
-            <Typography>Debug logging</Typography>
-            <Switch value={isDebugMode} onValueChange={setIsDebugMode} />
-          </View>
-          <View style={styles.option}>
-            <Typography>Toggle Theme</Typography>
-            <Switch value={scheme === "light"} onValueChange={toggleScheme} />
-          </View>
-          <SourceSelect />
-        </View>
+      <View
+        style={[
+          {
+            borderColor: colors.primary,
+          },
+          styles.tabsContainer,
+        ]}
+      >
+        {Object.entries(tabsWithNames).map(([key, label]) => (
+          <Pressable key={key} onPress={() => setTab(key as SettingsTab)}>
+            <Typography color={key === tab ? colors.primary : undefined}>{label}</Typography>
+          </Pressable>
+        ))}
       </View>
-      <ViewHistory />
+      {tabContent[tab]}
     </Screen>
   );
 };

--- a/OwnTube.tv/screens/SettingsScreen/styles.ts
+++ b/OwnTube.tv/screens/SettingsScreen/styles.ts
@@ -6,11 +6,5 @@ export const styles = StyleSheet.create({
     gap: 10,
     padding: 20,
   },
-  deviceInfoAndToggles: { flexDirection: "row", flexWrap: "wrap", gap: 16, width: "100%" },
-  option: {
-    alignItems: "center",
-    flexDirection: "row",
-    gap: 5,
-  },
-  togglesContainer: { flex: 1, minWidth: 200 },
+  tabsContainer: { borderRadius: 8, borderWidth: 1, flexDirection: "row", gap: 8, padding: 8 },
 });


### PR DESCRIPTION
## 🚀 Description

This PR introduces the ability to select a custom Peertube instance from Sepia search in Settings view, separates the Settings view into tabs to declutter the UI.
See deployed at https://mykhailodanilenko.github.io/web-client/

## 📄 Motivation and Context

#72 

## 🧪 How Has This Been Tested?

desktop web

## 📷 Screenshots (if appropriate)

<img width="678" alt="image" src="https://github.com/OwnTube-tv/web-client/assets/53569595/065f1226-f6ec-438c-af5e-357cc6462754">


## 📦 Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist (copied from README)

- [x] Squash your changes into a single clear and thoroughly descriptive commit, split changes into multiple commits only when it contributes to readability
- [x] Reference the GitHub issue that you are contributing on in your commit title or body
- [x] Sign your commits, as this is required by the automated GitHub PR checks
- [x] Ensure that the changes adhere to the project code style and formatting rules by running `npx eslint .` and `npx prettier --check ../` from the `./OwnTube.tv/` directory (without errors/warnings)
- [x] Include links and illustrations in your pull request to make it easy to review
- [x] Request a review by @mykhailodanilenko, @ar9708 and @mblomdahl
