### PR TITLE
Make accessible external links

### DIFF
--- a/OwnTube.tv/.eslintrc.json
+++ b/OwnTube.tv/.eslintrc.json
@@ -18,7 +18,7 @@
   },
   "plugins": ["@typescript-eslint", "react", "react-native"],
   "rules": {
-    "react-native/no-raw-text": ["error", { "skip": ["Typography", "title"] }],
+    "react-native/no-raw-text": ["error", { "skip": ["Typography", "title", "ExternalLink"] }],
     "react/prop-types": "off",
     "react-native/no-inline-styles": "off"
   },

--- a/OwnTube.tv/components/BuildInfoToast.tsx
+++ b/OwnTube.tv/components/BuildInfoToast.tsx
@@ -1,8 +1,9 @@
-import { Linking, StyleSheet, View } from "react-native";
+import { StyleSheet, View } from "react-native";
 import { Typography } from "./Typography";
 import build_info from "../build-info.json";
 import { useTheme } from "@react-navigation/native";
 import { removeSecondsFromISODate } from "../utils";
+import { ExternalLink } from "./ExternalLink";
 
 export const BuildInfoToast = () => {
   const { colors } = useTheme();
@@ -11,17 +12,17 @@ export const BuildInfoToast = () => {
     <View style={[{ backgroundColor: colors.card }, styles.container]}>
       <Typography fontSize={14} style={{ userSelect: "none" }}>
         Revision{" "}
-        <Typography fontSize={14} style={styles.link} onPress={() => Linking.openURL(build_info.COMMIT_URL)}>
-          {build_info.GITHUB_SHA_SHORT}
-        </Typography>{" "}
+        <ExternalLink absoluteHref={build_info.COMMIT_URL}>
+          <Typography fontSize={14} style={styles.link}>
+            {build_info.GITHUB_SHA_SHORT}
+          </Typography>{" "}
+        </ExternalLink>
         built at {removeSecondsFromISODate(build_info.BUILD_TIMESTAMP)} by{" "}
-        <Typography
-          fontSize={14}
-          style={styles.link}
-          onPress={() => Linking.openURL("https://github.com/" + build_info.GITHUB_ACTOR)}
-        >
-          {build_info.GITHUB_ACTOR}
-        </Typography>
+        <ExternalLink absoluteHref={"https://github.com/" + build_info.GITHUB_ACTOR}>
+          <Typography fontSize={14} style={styles.link}>
+            {build_info.GITHUB_ACTOR}
+          </Typography>
+        </ExternalLink>
       </Typography>
     </View>
   );

--- a/OwnTube.tv/components/ExternalLink.tsx
+++ b/OwnTube.tv/components/ExternalLink.tsx
@@ -1,0 +1,21 @@
+import { Platform } from "react-native";
+import { Link } from "expo-router";
+import { ExpoRouter } from "expo-router/types/expo-router";
+import { PropsWithChildren } from "react";
+
+export const ExternalLink = (
+  props: PropsWithChildren<Omit<ExpoRouter.LinkProps, "href"> & { absoluteHref: string }>,
+) => {
+  return (
+    <>
+      {Platform.select({
+        web: (
+          <a href={props.absoluteHref} style={{ textDecoration: "none" }}>
+            {props.children}
+          </a>
+        ),
+        default: <Link {...props} href={{ pathname: props.absoluteHref }} />,
+      })}
+    </>
+  );
+};

--- a/OwnTube.tv/components/SourceSelect.tsx
+++ b/OwnTube.tv/components/SourceSelect.tsx
@@ -1,15 +1,16 @@
 import { useCallback, useMemo } from "react";
-import { Linking, Pressable, StyleSheet, View } from "react-native";
+import { StyleSheet, View } from "react-native";
 import { SOURCES, STORAGE } from "../types";
 import { Typography } from "./Typography";
 import { useTheme } from "@react-navigation/native";
-import { Link, useLocalSearchParams, useRouter } from "expo-router";
+import { useLocalSearchParams, useRouter } from "expo-router";
 import { writeToAsyncStorage } from "../utils";
 import { RootStackParams } from "../app/_layout";
 import { useGetInstancesQuery } from "../api";
 import { ComboBoxInput } from "./ComboBoxInput";
 import { Spacer } from "./shared/Spacer";
 import { colors } from "../colors";
+import { ExternalLink } from "./ExternalLink";
 import { useRecentInstances } from "../hooks";
 import { Ionicons } from "@expo/vector-icons";
 
@@ -55,9 +56,9 @@ export const SourceSelect = () => {
       {backend && (
         <View style={{ flexDirection: "row" }}>
           <Typography>Selected instance: </Typography>
-          <Pressable onPress={() => Linking.openURL(`https://${backend}/`)}>
+          <ExternalLink absoluteHref={`https://${backend}/`}>
             <Typography color={theme.colors.primary}>{backend}</Typography>
-          </Pressable>
+          </ExternalLink>
         </View>
       )}
       <Spacer height={16} />
@@ -75,17 +76,17 @@ export const SourceSelect = () => {
             </Ionicons.Button>
           </View>
           {recentInstances?.map(renderItem)}
+          <Spacer height={16} />
         </>
       )}
-      <Spacer height={16} />
       <Typography>Predefined instances:</Typography>
       {Object.values(SOURCES).map(renderItem)}
       {backend && backend in SOURCES && renderItem(backend)}
       <Spacer height={16} />
       <Typography>
-        <Link style={{ textDecorationLine: "underline", color: colors.sepia }} href={"https://sepiasearch.org/"}>
-          Sepia
-        </Link>{" "}
+        <ExternalLink absoluteHref={"https://sepiasearch.org/"}>
+          <Typography color={colors.sepia}>Sepia</Typography>
+        </ExternalLink>{" "}
         PeerTube instances:
       </Typography>
       <Spacer height={16} />


### PR DESCRIPTION
## 🚀 Description

This PR replaces external links made with touchable text for real links on the web. The reason why we are adding this change is https://github.com/expo/expo/issues/26566 so once it is resolved we can go on to remove this customization in favor of keeping expo-router Link components everywhere
See deployed at https://mykhailodanilenko.github.io/web-client/

## 📄 Motivation and Context

#98 

## 🧪 How Has This Been Tested?

web & mobile

## Screenshots

<img width="398" alt="image" src="https://github.com/OwnTube-tv/web-client/assets/53569595/9dee1e76-bc94-4715-b216-2b316b27315e">

## 📦 Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist (copied from README)

- [x] Squash your changes into a single clear and thoroughly descriptive commit, split changes into multiple commits only when it contributes to readability
- [x] Reference the GitHub issue that you are contributing on in your commit title or body
- [x] Sign your commits, as this is required by the automated GitHub PR checks
- [x] Ensure that the changes adhere to the project code style and formatting rules by running `npx eslint .` and `npx prettier --check ../` from the `./OwnTube.tv/` directory (without errors/warnings)
- [x] Include links and illustrations in your pull request to make it easy to review
- [x] Request a review by @mykhailodanilenko, @ar9708 and @mblomdahl
