### PR TITLE
Add settings modal

### DIFF
--- a/OwnTube.tv/components/DeviceCapabilities.tsx
+++ b/OwnTube.tv/components/DeviceCapabilities.tsx
@@ -1,11 +1,26 @@
 import { Pressable, StyleSheet, View } from "react-native";
 import { Typography } from "./Typography";
 import * as Clipboard from "expo-clipboard";
-import { Spacer } from "./shared/Spacer";
 import { useAppConfigContext } from "../contexts";
 import { useTheme } from "@react-navigation/native";
 import { useTranslation } from "react-i18next";
 import { IcoMoonIcon } from "./IcoMoonIcon";
+import { borderRadius } from "../theme";
+
+const CapabilityKeyValuePair = ({ label, value }: { label: string; value: string }) => {
+  const { colors } = useTheme();
+
+  return (
+    <View style={styles.row}>
+      <Typography color={colors.themeDesaturated500} fontSize="sizeXS" fontWeight="Medium">
+        {label}
+      </Typography>
+      <Typography color={colors.themeDesaturated500} fontSize="sizeXS" fontWeight="Medium">
+        {value}
+      </Typography>
+    </View>
+  );
+};
 
 export const DeviceCapabilities = () => {
   const { deviceCapabilities } = useAppConfigContext();
@@ -17,52 +32,41 @@ export const DeviceCapabilities = () => {
   };
 
   return (
-    <View style={[{ backgroundColor: colors.card }, styles.modalContainer]}>
+    <View style={{ backgroundColor: colors.theme50 }}>
       <View style={styles.modalHeader}>
-        <Typography>{t("deviceCapabilityInfoTitle")}</Typography>
-        <Pressable onPress={handleCopyToClipboard}>
-          <IcoMoonIcon color={colors.primary} name="Content-Copy" size={24} />
+        <Typography fontSize="sizeSm" fontWeight="SemiBold" color={colors.theme950}>
+          {t("deviceCapabilityInfoTitle")}
+        </Typography>
+        <Pressable onPress={handleCopyToClipboard} style={[styles.iconButton, { backgroundColor: colors.theme500 }]}>
+          <IcoMoonIcon color={colors.white94} name="Content-Copy" size={24} />
         </Pressable>
       </View>
-      <Spacer height={16} />
-      <View style={styles.row}>
-        <Typography>{t("playerImpl")}</Typography>
-        <Typography>{deviceCapabilities.playerImplementation}</Typography>
-      </View>
-      <View style={styles.row}>
-        <Typography>{t("deviceType")}</Typography>
-        <Typography>{deviceCapabilities.deviceType}</Typography>
-      </View>
-      <View style={styles.row}>
-        <Typography>{t("operatingSystem")}</Typography>
-        <Typography>{deviceCapabilities.OS}</Typography>
-      </View>
-      {deviceCapabilities.browser && (
-        <View style={styles.row}>
-          <Typography>{t("browser")}</Typography>
-          <Typography>{deviceCapabilities.browser}</Typography>
-        </View>
-      )}
-      {deviceCapabilities.device && (
-        <View style={styles.row}>
-          <Typography>{t("device")}</Typography>
-          <Typography>{deviceCapabilities.device}</Typography>
-        </View>
-      )}
-      <View style={styles.row}>
-        <Typography>{t("screenDimensions")}</Typography>
-        <Typography>{deviceCapabilities.dimensions}</Typography>
-      </View>
-      <View style={styles.row}>
-        <Typography>{t("orientation")}</Typography>
-        <Typography>{deviceCapabilities.orientation}</Typography>
+      <View style={styles.capabilitiesContainer}>
+        <CapabilityKeyValuePair label={t("playerImpl")} value={deviceCapabilities.playerImplementation} />
+        <CapabilityKeyValuePair label={t("deviceType")} value={deviceCapabilities.deviceType} />
+        <CapabilityKeyValuePair label={t("operatingSystem")} value={deviceCapabilities.OS} />
+        {deviceCapabilities.browser && (
+          <CapabilityKeyValuePair label={t("browser")} value={deviceCapabilities.browser} />
+        )}
+        {deviceCapabilities.device && <CapabilityKeyValuePair label={t("device")} value={deviceCapabilities.device} />}
+        <CapabilityKeyValuePair label={t("screenDimensions")} value={deviceCapabilities.dimensions} />
+        <CapabilityKeyValuePair label={t("orientation")} value={deviceCapabilities.orientation} />
       </View>
     </View>
   );
 };
 
 const styles = StyleSheet.create({
-  modalContainer: { borderRadius: 8, minWidth: "50%", padding: 16 },
+  capabilitiesContainer: {
+    gap: 8,
+  },
+  iconButton: {
+    alignItems: "center",
+    borderRadius: borderRadius.radiusMd,
+    height: 36,
+    justifyContent: "center",
+    width: 36,
+  },
   modalHeader: { flexDirection: "row", gap: 16, justifyContent: "space-between" },
-  row: { flexWrap: "wrap", justifyContent: "space-between", marginVertical: 8, width: "100%" },
+  row: { flexWrap: "wrap", justifyContent: "space-between", width: "100%" },
 });

--- a/OwnTube.tv/components/FullScreenModal.tsx
+++ b/OwnTube.tv/components/FullScreenModal.tsx
@@ -2,6 +2,7 @@ import Animated, { FadeIn, FadeOut } from "react-native-reanimated";
 import { Pressable, StyleSheet, View } from "react-native";
 import { FC, PropsWithChildren } from "react";
 import { colors } from "../theme";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 interface FullScreenModalProps {
   isVisible: boolean;
@@ -15,12 +16,14 @@ export const FullScreenModal: FC<PropsWithChildren<FullScreenModalProps>> = ({
   onBackdropPress,
   children,
 }) => {
+  const { top } = useSafeAreaInsets();
+
   if (!isVisible) {
     return null;
   }
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, { paddingTop: top }]}>
       <AnimatedPressable
         onPress={onBackdropPress}
         entering={FadeIn}

--- a/OwnTube.tv/components/VideoControlsOverlay/components/modals/Settings.tsx
+++ b/OwnTube.tv/components/VideoControlsOverlay/components/modals/Settings.tsx
@@ -1,0 +1,49 @@
+import Animated, { SlideInUp, SlideOutUp } from "react-native-reanimated";
+import { ModalContainer } from "../../../ModalContainer";
+import { ScrollView, StyleSheet } from "react-native";
+import { DeviceCapabilities } from "../../../DeviceCapabilities";
+import { Spacer } from "../../../shared/Spacer";
+import { spacing } from "../../../../theme";
+import { Checkbox, Picker, Separator } from "../../../shared";
+import { useAppConfigContext } from "../../../../contexts";
+import { useSelectLocale } from "../../../../hooks";
+import { LANGUAGE_OPTIONS } from "../../../../i18n";
+import { useTheme } from "@react-navigation/native";
+
+interface SettingsProps {
+  onClose: () => void;
+}
+
+export const Settings = ({ onClose }: SettingsProps) => {
+  const { isDebugMode, setIsDebugMode } = useAppConfigContext();
+  const { currentLang, handleChangeLang, t } = useSelectLocale();
+  const { dark: isDarkTheme } = useTheme();
+
+  return (
+    <Animated.View entering={SlideInUp} exiting={SlideOutUp} style={styles.animatedContainer} pointerEvents="box-none">
+      <ModalContainer onClose={onClose} title={t("settingsPageTitle")} containerStyle={styles.modalContainer}>
+        <ScrollView>
+          <Spacer height={spacing.sm} />
+          <DeviceCapabilities />
+          <Spacer height={spacing.xl} />
+          <Separator />
+          <Spacer height={spacing.xl} />
+          <Picker
+            darkTheme={isDarkTheme}
+            placeholder={{}}
+            value={currentLang}
+            onValueChange={handleChangeLang}
+            items={LANGUAGE_OPTIONS}
+          />
+          <Spacer height={spacing.xl} />
+          <Checkbox checked={isDebugMode} onChange={setIsDebugMode} label={t("debugLogging")} />
+        </ScrollView>
+      </ModalContainer>
+    </Animated.View>
+  );
+};
+
+const styles = StyleSheet.create({
+  animatedContainer: { alignItems: "center", flex: 1, justifyContent: "center" },
+  modalContainer: { maxHeight: "90%", maxWidth: "90%", width: 500 },
+});

--- a/OwnTube.tv/components/VideoControlsOverlay/components/modals/index.ts
+++ b/OwnTube.tv/components/VideoControlsOverlay/components/modals/index.ts
@@ -1,2 +1,3 @@
 export * from "./VideoDetails";
 export * from "./Share";
+export * from "./Settings";

--- a/OwnTube.tv/components/shared/Picker.tsx
+++ b/OwnTube.tv/components/shared/Picker.tsx
@@ -1,0 +1,74 @@
+import RNPickerSelect, { PickerSelectProps } from "react-native-picker-select";
+import { borderRadius, fontSizes, fontWeights, spacing } from "../../theme";
+import { StyleSheet, View } from "react-native";
+import { useTheme } from "@react-navigation/native";
+import { IcoMoonIcon } from "../IcoMoonIcon";
+import { useMemo, useState } from "react";
+
+export const Picker = (props: PickerSelectProps) => {
+  const { colors } = useTheme();
+  const containerStyle = useMemo(
+    () => ({
+      ...styles.container,
+      backgroundColor: colors.theme100,
+      borderColor: colors.theme200,
+    }),
+    [colors],
+  );
+
+  const textStyle = useMemo(
+    () => ({
+      fontSize: fontSizes.sizeSm,
+      fontWeight: fontWeights.Medium,
+      fontFamily: "Inter_500Medium",
+      lineHeight: 17,
+      color: colors.theme950,
+    }),
+    [colors],
+  );
+
+  const [isPickerOpen, setIsPickerOpen] = useState(false);
+
+  return (
+    <RNPickerSelect
+      {...props}
+      style={{
+        inputWeb: { ...containerStyle, ...textStyle },
+        placeholder: textStyle,
+        inputIOSContainer: containerStyle,
+        inputIOS: textStyle,
+        inputAndroidContainer: containerStyle,
+        inputAndroid: { ...textStyle, fontWeight: "500" },
+        headlessAndroidPicker: { backgroundColor: "red" },
+        ...props.style,
+      }}
+      Icon={() => (
+        <View
+          pointerEvents="none"
+          style={[styles.chevronContainer, { transform: [{ rotate: isPickerOpen ? "180deg" : "0deg" }] }]}
+        >
+          <IcoMoonIcon name="Chevron" size={24} color={colors.theme500} />
+        </View>
+      )}
+      useNativeAndroidPickerStyle={false}
+      onOpen={() => setIsPickerOpen(true)}
+      onClose={() => setIsPickerOpen(false)}
+      pickerProps={{
+        onFocus: () => setIsPickerOpen(true),
+        onBlur: () => setIsPickerOpen(false),
+      }}
+    />
+  );
+};
+
+const styles = StyleSheet.create({
+  chevronContainer: { paddingHorizontal: 16, paddingVertical: 12 },
+  container: {
+    alignItems: "center",
+    borderRadius: borderRadius.radiusMd,
+    borderWidth: 1,
+    flexDirection: "row",
+    height: 48,
+    paddingLeft: spacing.lg,
+  },
+});

--- a/OwnTube.tv/components/shared/index.ts
+++ b/OwnTube.tv/components/shared/index.ts
@@ -3,3 +3,4 @@ export * from "./Error";
 export * from "./Separator";
 export * from "./Checkbox";
 export * from "./Input";
+export * from "./Picker";

--- a/OwnTube.tv/global.css
+++ b/OwnTube.tv/global.css
@@ -1,3 +1,9 @@
 input:focus {
   outline: none;
 }
+
+select {
+  -moz-appearance: none !important;
+  -webkit-appearance: none !important;
+  appearance: none !important;
+}

--- a/OwnTube.tv/locales/en.json
+++ b/OwnTube.tv/locales/en.json
@@ -11,7 +11,7 @@
   "toggleTheme": "Toggle Theme",
   "revision": "Revision",
   "builtAtBy": "built at {{builtAt}} by",
-  "deviceCapabilityInfoTitle": "Device Capability info:",
+  "deviceCapabilityInfoTitle": "Device capability information",
   "playerImpl": "Player implementation:",
   "deviceType": "Device type:",
   "operatingSystem": "Operating system:",

--- a/OwnTube.tv/locales/ru.json
+++ b/OwnTube.tv/locales/ru.json
@@ -11,7 +11,7 @@
   "toggleTheme": "Переключить тему",
   "revision": "Ревизия",
   "builtAtBy": "поставка от {{builtAt}} авторства",
-  "deviceCapabilityInfoTitle": "Информация о возможностях устройства:",
+  "deviceCapabilityInfoTitle": "Информация о возможностях устройства",
   "playerImpl": "Реализация плеера:",
   "deviceType": "Тип устройства:",
   "operatingSystem": "Операционная система:",

--- a/OwnTube.tv/locales/uk.json
+++ b/OwnTube.tv/locales/uk.json
@@ -11,7 +11,7 @@
   "toggleTheme": "Змінити тему",
   "revision": "Ревізія",
   "builtAtBy": "поставка від {{builtAt}} авторства",
-  "deviceCapabilityInfoTitle": "Інформація про можливості пристрою:",
+  "deviceCapabilityInfoTitle": "Інформація про можливості пристрою",
   "playerImpl": "Реалізація плеєра:",
   "deviceType": "Тип пристрою:",
   "operatingSystem": "Операційна система:",

--- a/OwnTube.tv/package-lock.json
+++ b/OwnTube.tv/package-lock.json
@@ -14,6 +14,7 @@
         "@expo/vector-icons": "^14.0.2",
         "@peertube/peertube-types": "^6.1.0",
         "@react-native-async-storage/async-storage": "^1.23.1",
+        "@react-native-picker/picker": "2.7.5",
         "@react-navigation/native": "^6.1.17",
         "@react-navigation/native-stack": "^6.9.26",
         "@tanstack/react-query": "^5.40.0",
@@ -43,6 +44,7 @@
         "react-i18next": "^14.1.2",
         "react-native": "0.74.3",
         "react-native-gesture-handler": "~2.16.1",
+        "react-native-picker-select": "^9.2.0",
         "react-native-reanimated": "~3.10.1",
         "react-native-safe-area-context": "4.10.5",
         "react-native-screens": "3.31.1",
@@ -8137,6 +8139,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@react-native-picker/picker": {
+      "version": "2.7.5",
+      "resolved": "https://registry.npmjs.org/@react-native-picker/picker/-/picker-2.7.5.tgz",
+      "integrity": "sha512-vhMaOLkXSUb+YKVbukMJToU4g+89VMhBG2U9+cLYF8X8HtFRidrHjohGqT8/OyesDuKIXeLIP+UFYI9Q9CRA9Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/@react-native/assets-registry": {
@@ -19864,6 +19876,18 @@
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
       "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="
     },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isobject": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
+      "integrity": "sha512-3/Qptq2vr7WeJbB4KHUSKlq8Pl7ASXi3UG6CMbBm8WRtXi8+GHm7mKaU3urfpSEzWe2wCIChs6/sdocUsTKJiA==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -22979,6 +23003,19 @@
       },
       "peerDependencies": {
         "react": "^16.6.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-native-picker-select": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-native-picker-select/-/react-native-picker-select-9.2.0.tgz",
+      "integrity": "sha512-jFvogSMFuTIYorp/r95HnJHmoHyilZFAcETgxMylwaF+4T7cWYWoTXzB0+g89hljPH4LMsr+3q+PAuJouLPvIw==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.isequal": "^4.5.0",
+        "lodash.isobject": "^3.0.2"
+      },
+      "peerDependencies": {
+        "@react-native-picker/picker": "^2.4.0"
       }
     },
     "node_modules/react-native-reanimated": {

--- a/OwnTube.tv/package.json
+++ b/OwnTube.tv/package.json
@@ -47,6 +47,7 @@
     "react-i18next": "^14.1.2",
     "react-native": "0.74.3",
     "react-native-gesture-handler": "~2.16.1",
+    "react-native-picker-select": "^9.2.0",
     "react-native-reanimated": "~3.10.1",
     "react-native-safe-area-context": "4.10.5",
     "react-native-screens": "3.31.1",
@@ -56,7 +57,8 @@
     "react-qr-code": "^2.0.15",
     "react-test-renderer": "18.2.0",
     "ua-parser-js": "^1.0.38",
-    "video.js": "^8.12.0"
+    "video.js": "^8.12.0",
+    "@react-native-picker/picker": "2.7.5"
   },
   "devDependencies": {
     "@babel/core": "^7.24.0",

--- a/OwnTube.tv/screens/VideoScreen/index.tsx
+++ b/OwnTube.tv/screens/VideoScreen/index.tsx
@@ -7,7 +7,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Loader, FocusWrapper, FullScreenModal } from "../../components";
 import { useViewHistory, useFullScreenVideoPlayback } from "../../hooks";
 import { StatusBar } from "expo-status-bar";
-import { Share, VideoDetails } from "../../components/VideoControlsOverlay/components/modals";
+import { Settings, Share, VideoDetails } from "../../components/VideoControlsOverlay/components/modals";
 import { Platform, StyleSheet, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useColorSchemeContext } from "../../contexts";
@@ -82,7 +82,7 @@ export const VideoScreen = () => {
         backgroundColor="black"
         style={Platform.OS === "android" ? "light" : scheme === "dark" ? "light" : "dark"}
       />
-      <View id="video-container" style={[{ marginTop: top }, styles.videoContainer]}>
+      <View id="video-container" style={[{ paddingTop: top }, styles.videoContainer]}>
         <VideoView
           timestamp={params?.timestamp}
           handleSetTimeStamp={handleSetTimeStamp}
@@ -111,6 +111,9 @@ export const VideoScreen = () => {
         </FullScreenModal>
         <FullScreenModal onBackdropPress={closeModal} isVisible={visibleModal === "share"}>
           <Share onClose={closeModal} />
+        </FullScreenModal>
+        <FullScreenModal onBackdropPress={closeModal} isVisible={visibleModal === "settings"}>
+          <Settings onClose={closeModal} />
         </FullScreenModal>
       </View>
     </FocusWrapper>

--- a/docs/tech.md
+++ b/docs/tech.md
@@ -45,6 +45,14 @@ Through video.js we are converting the hls stream into a stream of mp4 chunks wh
 The video controls are overlaid above the video player, this way the experience is unified regardless of the platform.
 You can skip 10 seconds in each direction, seek through the video, play/pause, mute.
 
+You can also control the player with your keyboard. See shortcuts below:
+
+- [F]: toggle fullscreen;
+- [M]: toggle mute;
+- [->]: skip forward;
+- [<-]: skip backward;
+- [spacebar]: toggle play/pause;
+
 ### Testing ⚙️
 
 Jest is used throughout the app for testing, both for component tests and unit tests. For testing React components, the


### PR DESCRIPTION
## 🚀 Description

This PR add settings modal to the video screen, while not adding the instance select functionality until further discussion. Also, the keyboard shortcuts for the player are documented. See deployed at https://mykhailodanilenko.github.io/web-client/

## 📄 Motivation and Context

#119 

## 🧪 How Has This Been Tested?

Safari & Chrome for desktop & mobile and iOS & android native implementations through Expo Go

## 📷 Screenshots (if appropriate)

The select element has been adapted to look native on all platforms:
iOS:
![simulator_screenshot_CF19B125-5984-49BE-874D-42AD294FB4BA](https://github.com/user-attachments/assets/9675eba2-eb7e-467f-a5e1-312d8729ebed)
Android:
<img width="288" alt="image" src="https://github.com/user-attachments/assets/e0b22ecb-0a33-4488-976d-86855572298e">
Web:
![image](https://github.com/user-attachments/assets/9f1a95d0-9835-46d7-a0b1-3ebe7ca80da6)


## 📦 Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist (copied from README)

- [x] Squash your changes into a single clear and thoroughly descriptive commit, split changes into multiple commits only when it contributes to readability
- [x] Reference the GitHub issue that you are contributing on in your commit title or body
- [x] Sign your commits, as this is required by the automated GitHub PR checks
- [x] Ensure that the changes adhere to the project code style and formatting rules by running `npx eslint .` and `npx prettier --check ../` from the `./OwnTube.tv/` directory (without errors/warnings)
- [x] Include links and illustrations in your pull request to make it easy to review
- [x] Request a review by @mykhailodanilenko, @ar9708 and @mblomdahl
