### PR TITLE
Add video thumbnail according to design

### DIFF
--- a/OwnTube.tv/api/models.ts
+++ b/OwnTube.tv/api/models.ts
@@ -1,5 +1,6 @@
 // Subset of a video object from the PeerTube backend API, https://github.com/Chocobozzz/PeerTube/blob/develop/server/core/models/video/video.ts#L460
 import { VideoModel } from "@peertube/peertube-types/server/core/models/video/video";
+import { VideoChannelSummary } from "@peertube/peertube-types";
 
 export interface Channel {
   id: number;
@@ -21,10 +22,13 @@ export interface Channel {
   };
 }
 
-export type GetVideosVideo = Pick<VideoModel, "uuid" | "name" | "description" | "duration"> & {
+export type GetVideosVideo = Pick<
+  VideoModel,
+  "uuid" | "name" | "description" | "duration" | "publishedAt" | "originallyPublishedAt" | "views"
+> & {
   thumbnailPath: string;
   category: { id: number | null; label: string };
-  channel: Channel;
+  channel: VideoChannelSummary;
 };
 
 export type PeertubeInstance = {

--- a/OwnTube.tv/api/peertubeVideosApi.ts
+++ b/OwnTube.tv/api/peertubeVideosApi.ts
@@ -142,6 +142,9 @@ export class PeertubeVideosApi {
         thumbnailPath: video.thumbnailPath,
         duration: video.duration,
         channel: video.channel,
+        publishedAt: video.publishedAt,
+        originallyPublishedAt: video.originallyPublishedAt,
+        views: video.views,
       };
     });
   }

--- a/OwnTube.tv/components/CategoryScroll.tsx
+++ b/OwnTube.tv/components/CategoryScroll.tsx
@@ -1,12 +1,13 @@
 import { FC, useCallback, useState } from "react";
 import { View, StyleSheet, FlatList, ViewToken } from "react-native";
 import { useCategoryScroll, useViewHistory } from "../hooks";
-import { Button, VideoThumbnail } from "./";
+import { Button } from "./";
 import { useTheme } from "@react-navigation/native";
 import { GetVideosVideo } from "../api/models";
 import { useLocalSearchParams } from "expo-router";
 import { RootStackParams } from "../app/_layout";
 import { ROUTES } from "../types";
+import { VideoGridCard } from "./VideoGridCard";
 
 export const CategoryScroll: FC<{ videos: GetVideosVideo[] }> = ({ videos }) => {
   const { backend } = useLocalSearchParams<RootStackParams[ROUTES.INDEX]>();
@@ -20,12 +21,12 @@ export const CategoryScroll: FC<{ videos: GetVideosVideo[] }> = ({ videos }) => 
       const { timestamp } = getViewHistoryEntryByUuid(video.uuid) || {};
 
       return (
-        <VideoThumbnail
-          isVisible={viewableItems.includes(video.uuid)}
-          key={video.uuid}
+        <VideoGridCard
           video={video}
           backend={backend}
           timestamp={timestamp}
+          key={video.uuid}
+          isVisible={viewableItems.includes(video.uuid)}
         />
       );
     },
@@ -91,7 +92,7 @@ const styles = StyleSheet.create({
     overflow: "visible",
   },
   videoThumbnailsContainer: {
-    alignItems: "center",
+    alignItems: "flex-start",
     flexDirection: "row",
     gap: 8,
   },

--- a/OwnTube.tv/components/ResumeWatching.tsx
+++ b/OwnTube.tv/components/ResumeWatching.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from "react-i18next";
 
 export const ResumeWatching = () => {
   const { t } = useTranslation();
-  const { viewHistory, isFetching } = useViewHistory();
+  const { viewHistory, isFetching, deleteVideoFromHistory } = useViewHistory();
   const latestVideo = viewHistory?.[0];
 
   if (!latestVideo || isFetching) {
@@ -19,7 +19,10 @@ export const ResumeWatching = () => {
       <Spacer height={16} />
       <Typography>{t("continueWatching")}</Typography>
       <Spacer height={16} />
-      <ViewHistoryListItem video={latestVideo} />
+      <ViewHistoryListItem
+        handleDeleteFromHistory={() => deleteVideoFromHistory(latestVideo?.uuid)}
+        video={latestVideo}
+      />
       <Spacer height={16} />
     </View>
   );

--- a/OwnTube.tv/components/VideoGridCard.tsx
+++ b/OwnTube.tv/components/VideoGridCard.tsx
@@ -1,0 +1,80 @@
+import { Pressable, StyleSheet, View } from "react-native";
+import { VideoThumbnail } from "./VideoThumbnail";
+import { GetVideosVideo } from "../api/models";
+import { Link } from "expo-router";
+import { ROUTES } from "../types";
+import { Typography } from "./Typography";
+import { spacing } from "../theme";
+import { useBreakpoints, useHoverState } from "../hooks";
+import { useTheme } from "@react-navigation/native";
+import { ChannelLink } from "./ChannelLink";
+import { formatDistanceToNow } from "date-fns";
+import { useTranslation } from "react-i18next";
+import { LANGUAGE_OPTIONS } from "../i18n";
+
+interface VideoGridCardProps {
+  video: GetVideosVideo;
+  backend?: string;
+  timestamp?: number;
+  isVisible?: boolean;
+}
+
+export const VideoGridCard = ({ video, backend, timestamp, isVisible }: VideoGridCardProps) => {
+  const { isDesktop } = useBreakpoints();
+  const { colors } = useTheme();
+  const { isHovered, toggleHovered } = useHoverState();
+  const { t, i18n } = useTranslation();
+
+  return (
+    <View style={styles.container}>
+      <Pressable style={styles.pressableContainer} onPress={null} onHoverIn={toggleHovered} onHoverOut={toggleHovered}>
+        <Link
+          style={styles.linkWrapper}
+          href={{ pathname: `/${ROUTES.VIDEO}`, params: { id: video.uuid, backend, timestamp } }}
+        >
+          <VideoThumbnail
+            imageDimensions={{ width: 360, height: 202.5 }}
+            isVisible={isVisible}
+            video={video}
+            timestamp={timestamp}
+            backend={backend}
+          />
+        </Link>
+        <View style={styles.textContainer}>
+          <Link href={{ pathname: ROUTES.VIDEO, params: { id: video.uuid, backend } }}>
+            <View>
+              <Typography
+                fontWeight="Medium"
+                color={colors.theme900}
+                fontSize={isDesktop ? "sizeMd" : "sizeSm"}
+                numberOfLines={4}
+                style={{ textDecorationLine: isHovered ? "underline" : undefined }}
+              >
+                {video.name}
+              </Typography>
+            </View>
+          </Link>
+        </View>
+      </Pressable>
+      <View style={styles.restInfoContainer}>
+        <ChannelLink href="#" text={video.channel.displayName} />
+        <Typography fontSize="sizeXS" fontWeight="Medium" color={colors.themeDesaturated500}>
+          {`${formatDistanceToNow(video.publishedAt, { addSuffix: true, locale: LANGUAGE_OPTIONS.find(({ value }) => value === i18n.language)?.dateLocale })} • ${t("views", { count: video.views })}`}
+        </Typography>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    gap: spacing.sm,
+    height: "100%",
+    maxWidth: "100%",
+    width: 360,
+  },
+  linkWrapper: { flex: 1 },
+  pressableContainer: { gap: spacing.md },
+  restInfoContainer: { gap: spacing.xs, paddingHorizontal: spacing.sm },
+  textContainer: { gap: spacing.sm, paddingHorizontal: spacing.sm },
+});

--- a/OwnTube.tv/components/VideoThumbnail.tsx
+++ b/OwnTube.tv/components/VideoThumbnail.tsx
@@ -1,20 +1,20 @@
 import { View, Image, StyleSheet } from "react-native";
-import { getThumbnailDimensions } from "../utils";
 import { useColorSchemeContext } from "../contexts";
-import { Typography } from "./Typography";
 import { useTheme } from "@react-navigation/native";
 import { FC, useEffect, useState } from "react";
-import { Link } from "expo-router";
-import { ROUTES } from "../types";
 import { ViewHistoryEntry } from "../hooks";
 import { GetVideosVideo } from "../api/models";
 import { Loader } from "./Loader";
+import { borderRadius, spacing } from "../theme";
+import { Typography } from "./Typography";
+import { getHumanReadableDuration } from "../utils";
 
 interface VideoThumbnailProps {
   video: GetVideosVideo & Partial<ViewHistoryEntry>;
   backend?: string;
   timestamp?: number;
   isVisible?: boolean;
+  imageDimensions: { width: number; height: number };
 }
 
 const defaultImagePaths = {
@@ -22,11 +22,16 @@ const defaultImagePaths = {
   light: require("./../assets/Logo400x400.png"),
 };
 
-export const VideoThumbnail: FC<VideoThumbnailProps> = ({ video, backend, timestamp, isVisible = true }) => {
+export const VideoThumbnail: FC<VideoThumbnailProps> = ({
+  video,
+  backend,
+  timestamp,
+  isVisible = true,
+  imageDimensions,
+}) => {
   const { scheme } = useColorSchemeContext();
   const [shouldFetchThumbnail, setShouldFetchThumbnail] = useState(false);
 
-  const { width, height } = getThumbnailDimensions();
   const { colors } = useTheme();
 
   const percentageWatched = timestamp ? (timestamp / video.duration) * 100 : 0;
@@ -44,55 +49,54 @@ export const VideoThumbnail: FC<VideoThumbnailProps> = ({ video, backend, timest
   }
 
   return (
-    <Link
-      style={[styles.videoThumbnailContainer, { height, width }, { backgroundColor: colors.card }]}
-      href={{ pathname: `/${ROUTES.VIDEO}`, params: { id: video.uuid, backend, timestamp } }}
-    >
-      {shouldFetchThumbnail ? <Image source={imageSource} style={styles.videoImage} /> : <Loader />}
-      <View style={styles.textContainer}>
-        {!!percentageWatched && percentageWatched > 0 && (
-          <View style={styles.progressContainer}>
-            <View style={{ backgroundColor: colors.primary, width: `${percentageWatched}%`, height: "100%" }} />
-          </View>
-        )}
-        <Typography style={styles.videoTitle}>{video.name}</Typography>
+    <View style={[styles.videoThumbnailContainer, { backgroundColor: colors.themeDesaturated500 }]}>
+      {shouldFetchThumbnail ? (
+        <Image {...imageDimensions} resizeMode="cover" source={imageSource} style={styles.videoImage} />
+      ) : (
+        <Loader />
+      )}
+      {!!percentageWatched && percentageWatched > 0 && (
+        <View style={[styles.progressContainer, { backgroundColor: colors.white25 }]}>
+          <View style={{ backgroundColor: colors.theme500, width: `${percentageWatched}%`, height: spacing.xs }} />
+        </View>
+      )}
+      <View style={[styles.durationContainer, { backgroundColor: colors.black100 }]}>
+        <Typography color={colors.white94} fontSize="sizeXS" fontWeight="SemiBold">
+          {getHumanReadableDuration(video.duration * 1000)}
+        </Typography>
       </View>
-    </Link>
+    </View>
   );
 };
 
 const styles = StyleSheet.create({
+  durationContainer: {
+    borderRadius: borderRadius.radiusMd,
+    bottom: spacing.xs + 2,
+    padding: spacing.xs,
+    position: "absolute",
+    right: spacing.sm,
+    zIndex: 1,
+  },
   progressContainer: {
+    bottom: 0,
     flex: 1,
-    height: 4,
+    height: spacing.xs,
     left: 0,
     position: "absolute",
-    top: 0,
+    right: 0,
     width: "100%",
     zIndex: 1,
   },
-  textContainer: {
-    alignItems: "center",
-    padding: 10,
-    width: "100%",
-  },
   videoImage: {
-    borderTopLeftRadius: 10,
-    borderTopRightRadius: 10,
-    height: "85%",
-    resizeMode: "cover",
-    width: "100%",
+    aspectRatio: 16 / 9,
+    flex: 1,
   },
   videoThumbnailContainer: {
-    alignItems: "center",
-    borderRadius: 10,
-    elevation: 4,
-    flexDirection: "column",
-    marginBottom: 20,
-    shadowOpacity: 0.6,
-    shadowRadius: 3,
-  },
-  videoTitle: {
-    fontSize: 20,
+    aspectRatio: 16 / 9,
+    borderRadius: borderRadius.radiusMd,
+    flex: 1,
+    overflow: "hidden",
+    width: "100%",
   },
 });

--- a/OwnTube.tv/components/ViewHistory.tsx
+++ b/OwnTube.tv/components/ViewHistory.tsx
@@ -1,4 +1,4 @@
-import { useViewHistory } from "../hooks";
+import { useViewHistory, ViewHistoryEntry } from "../hooks";
 import { FlatList, StyleSheet, View } from "react-native";
 import { Loader } from "./Loader";
 import { Spacer } from "./shared/Spacer";
@@ -6,10 +6,18 @@ import { Typography } from "./Typography";
 import { ViewHistoryListItem } from "./ViewHistoryListItem";
 import { useTranslation } from "react-i18next";
 import { IconButton } from "./IconButton";
+import { useCallback } from "react";
 
 export const ViewHistory = () => {
   const { t } = useTranslation();
-  const { viewHistory, clearHistory, isFetching } = useViewHistory();
+  const { viewHistory, clearHistory, isFetching, deleteVideoFromHistory } = useViewHistory();
+
+  const renderItem = useCallback(
+    ({ item }: { item: ViewHistoryEntry }) => (
+      <ViewHistoryListItem handleDeleteFromHistory={() => deleteVideoFromHistory(item.uuid)} video={item} />
+    ),
+    [deleteVideoFromHistory],
+  );
 
   if (!viewHistory?.length && !isFetching) {
     return <Typography>{t("viewHistoryEmpty")}</Typography>;
@@ -25,11 +33,7 @@ export const ViewHistory = () => {
         <Typography style={styles.header}>{t("viewHistory")}</Typography>
         <IconButton icon="Trash" onPress={clearHistory} text={t("clear")} />
       </View>
-      <FlatList
-        renderItem={({ item }) => <ViewHistoryListItem video={item} />}
-        data={viewHistory}
-        ItemSeparatorComponent={() => <Spacer height={32} />}
-      />
+      <FlatList renderItem={renderItem} data={viewHistory} ItemSeparatorComponent={() => <Spacer height={32} />} />
     </View>
   );
 };

--- a/OwnTube.tv/components/ViewHistoryListItem.tsx
+++ b/OwnTube.tv/components/ViewHistoryListItem.tsx
@@ -1,38 +1,100 @@
 import { VideoThumbnail } from "./VideoThumbnail";
-import { StyleSheet, View } from "react-native";
+import { Pressable, StyleSheet, View } from "react-native";
 import { Typography } from "./Typography";
-import { getHumanReadableDuration } from "../utils";
 import { format } from "date-fns";
-import { ViewHistoryEntry } from "../hooks";
+import { useBreakpoints, useHoverState, ViewHistoryEntry } from "../hooks";
 import { useTranslation } from "react-i18next";
+import { Link } from "expo-router";
+import { ROUTES } from "../types";
+import { spacing } from "../theme";
+import { useTheme } from "@react-navigation/native";
+import { useMemo } from "react";
+import { ChannelLink } from "./ChannelLink";
+import { IcoMoonIcon } from "./IcoMoonIcon";
 
 interface ViewHistoryListItemProps {
   video: ViewHistoryEntry;
+  handleDeleteFromHistory: () => void;
 }
 
-export const ViewHistoryListItem = ({ video }: ViewHistoryListItemProps) => {
+export const ViewHistoryListItem = ({ video, handleDeleteFromHistory }: ViewHistoryListItemProps) => {
   const { t } = useTranslation();
+  const { colors } = useTheme();
+  const { isHovered, toggleHovered } = useHoverState();
+  const { isDesktop } = useBreakpoints();
+  const videoHref = useMemo(() => {
+    return {
+      pathname: `/${ROUTES.VIDEO}`,
+      params: { id: video.uuid, backend: video.backend, timestamp: video.timestamp },
+    };
+  }, [video]);
+
+  const deleteBtn = useMemo(() => {
+    return (
+      <Pressable onPress={handleDeleteFromHistory} style={{ padding: 6 }}>
+        <IcoMoonIcon color={colors.theme950} name="Trash" size={24} />
+      </Pressable>
+    );
+  }, [handleDeleteFromHistory, colors]);
 
   return (
-    <View style={styles.container}>
-      <VideoThumbnail video={video} backend={video.backend} key={video.uuid} timestamp={video.timestamp} />
-      <View>
-        <Typography>
-          {t("lastPlaybackTimeStamp", { timestamp: getHumanReadableDuration(video.timestamp * 1000) })}
-        </Typography>
-        <Typography>{t("videoDuration", { duration: getHumanReadableDuration(video.duration * 1000) })}</Typography>
-        <Typography>{t("associatedPeertubeBackend", { backend: video.backend })}</Typography>
-        {video.firstViewedAt && (
-          <Typography>{t("firstWatched", { date: format(new Date(video.firstViewedAt), "dd/M/yyyy p") })}</Typography>
-        )}
-        {video.lastViewedAt && (
-          <Typography>{t("lastWatched", { lastWatched: format(video.lastViewedAt, "dd/M/yyyy p") })}</Typography>
-        )}
+    <View style={[styles.container, { gap: isDesktop ? spacing.xl : spacing.md }]}>
+      <Link href={videoHref} style={styles.thumbLinkWrapper}>
+        <VideoThumbnail
+          imageDimensions={{ width: isDesktop ? 328 : 128, height: isDesktop ? 102 : 72 }}
+          video={video}
+          backend={video.backend}
+          key={video.uuid}
+          timestamp={video.timestamp}
+        />
+      </Link>
+      <View style={styles.infoContainer}>
+        <View style={styles.textContainer}>
+          {video.lastViewedAt && (
+            <View style={{ flexDirection: "row", justifyContent: "space-between" }}>
+              <Typography
+                fontWeight="Medium"
+                fontSize={isDesktop ? "sizeSm" : "sizeXS"}
+                color={colors.themeDesaturated500}
+                style={{ maxWidth: isDesktop ? null : 150 }}
+              >
+                {t("lastWatched", { lastWatched: format(video.lastViewedAt, "yyyy-MM-dd HH:mm") })}
+              </Typography>
+              {!isDesktop && deleteBtn}
+            </View>
+          )}
+          <Link asChild href={videoHref}>
+            <Pressable onHoverOut={toggleHovered} onHoverIn={toggleHovered}>
+              <Typography
+                style={{ textDecorationLine: isHovered ? "underline" : undefined }}
+                fontSize={isDesktop ? "sizeLg" : "sizeSm"}
+                fontWeight="SemiBold"
+                color={colors.theme900}
+                numberOfLines={4}
+              >
+                {video.name}
+              </Typography>
+            </Pressable>
+          </Link>
+          <ChannelLink href="#" text={video.channel?.displayName} />
+        </View>
+        {isDesktop && deleteBtn}
       </View>
     </View>
   );
 };
 
 const styles = StyleSheet.create({
-  container: { flexDirection: "row", flexWrap: "wrap", gap: 16 },
+  container: {
+    alignItems: "flex-start",
+    flexDirection: "row",
+    width: "100%",
+  },
+  infoContainer: { flexDirection: "row", flex: 1, justifyContent: "space-between" },
+  textContainer: {
+    flex: 1,
+    gap: spacing.sm,
+    height: "100%",
+  },
+  thumbLinkWrapper: { maxWidth: "37%", width: 328 },
 });

--- a/OwnTube.tv/components/index.ts
+++ b/OwnTube.tv/components/index.ts
@@ -25,3 +25,4 @@ export * from "./ChannelLink";
 export * from "./FullScreenModal";
 export * from "./PlatformCard";
 export * from "./InfoFooter";
+export * from "./VideoGridCard";

--- a/OwnTube.tv/hooks/useViewHistory.ts
+++ b/OwnTube.tv/hooks/useViewHistory.ts
@@ -78,5 +78,16 @@ export const useViewHistory = (enabled: boolean = true, maxItems: number = 50) =
     return history?.[uuid];
   };
 
-  return { viewHistory, isFetching, clearHistory, updateHistory, getViewHistoryEntryByUuid };
+  const deleteVideoFromHistory = async (uuid: string) => {
+    const history: string[] = await readFromAsyncStorage(STORAGE.VIEW_HISTORY);
+
+    await writeToAsyncStorage(
+      STORAGE.VIEW_HISTORY,
+      history.filter((entry) => entry !== uuid),
+    );
+    await deleteFromAsyncStorage([uuid]);
+    await queryClient.invalidateQueries({ queryKey: ["viewHistory"] });
+  };
+
+  return { viewHistory, isFetching, clearHistory, updateHistory, getViewHistoryEntryByUuid, deleteVideoFromHistory };
 };

--- a/OwnTube.tv/i18n.ts
+++ b/OwnTube.tv/i18n.ts
@@ -2,6 +2,8 @@ import i18next from "i18next";
 import { initReactI18next } from "react-i18next";
 import { en, uk, ru, sv } from "./locales";
 import { getLocales } from "expo-localization";
+import { enUS as enDateLocale, uk as ukDateLocale, ru as ruDateLocale, sv as svDateLocale } from "date-fns/locale";
+import "intl-pluralrules";
 
 export const FALLBACK_LANG = "en";
 
@@ -14,6 +16,8 @@ i18n.use(initReactI18next).init({
   fallbackLng: FALLBACK_LANG,
   defaultNS: "translation",
   lng: getLocales()[0]?.languageCode || undefined,
+  pluralSeparator: "_",
+  keySeparator: false,
 });
 
 i18n.addResourceBundle("en", "translation", en);
@@ -25,18 +29,22 @@ export const LANGUAGE_OPTIONS = [
   {
     label: "English",
     value: "en",
+    dateLocale: enDateLocale,
   },
   {
     label: "Українська",
     value: "uk",
+    dateLocale: ukDateLocale,
   },
   {
     label: "Русский",
     value: "ru",
+    dateLocale: ruDateLocale,
   },
   {
     label: "Svenska",
     value: "sv",
+    dateLocale: svDateLocale,
   },
 ];
 

--- a/OwnTube.tv/locales/en.json
+++ b/OwnTube.tv/locales/en.json
@@ -57,6 +57,10 @@
   "welcomeText": "Welcome to OwnTube!",
   "welcomeDescriptionText": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut laoreet, nisl dignissim gravida placerat, nunc nibh lacinia tortor faucibus ipsum.",
   "exploreVideoSites": "Explore video sites",
+  "views": "{{count}} views",
+  "views_zero": "{{count}} views",
+  "views_one": "{{count}} view",
+  "views_other": "{{count}} views",
   "errors": {
     "failedToFetchInstances": "Failed to fetch instances: {{error}}",
     "max100VideosPerChunk": "The maximum number of videos to fetch in a single request is 100",

--- a/OwnTube.tv/locales/ru.json
+++ b/OwnTube.tv/locales/ru.json
@@ -54,6 +54,10 @@
   "copy": "Копировать",
   "linkCopied": "Скопировано!",
   "startAt": "Начать с",
+  "views": "{{count}} просмотрsв",
+  "views_zero": "{{count}} просмотров",
+  "views_one": "{{count}} просмотр",
+  "views_other": "{{count}} просмотров",
   "errors": {
     "failedToFetchInstances": "Не удалось получить экземпляры: {{error}}",
     "max100VideosPerChunk": "Максимальное количество видео для одного запроса - 100",

--- a/OwnTube.tv/locales/uk.json
+++ b/OwnTube.tv/locales/uk.json
@@ -54,6 +54,10 @@
   "copy": "Копіювати",
   "linkCopied": "Скопійовано!",
   "startAt": "Почати з",
+  "views": "{{count}} переглядів",
+  "views_zero": "{{count}} переглядів",
+  "views_one": "{{count}} перегляд",
+  "views_other": "{{count}} переглядів",
   "errors": {
     "failedToFetchInstances": "Не вдалося отримати інстанції: {{error}}",
     "max100VideosPerChunk": "Максимальна кількість відео для одного запиту - 100",

--- a/OwnTube.tv/package-lock.json
+++ b/OwnTube.tv/package-lock.json
@@ -37,6 +37,7 @@
         "expo-screen-orientation": "~7.0.5",
         "expo-status-bar": "~1.12.1",
         "i18next": "^23.11.5",
+        "intl-pluralrules": "^2.0.1",
         "jest-expo": "~51.0.3",
         "patch-package": "^8.0.0",
         "react": "18.2.0",
@@ -16205,6 +16206,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/intl-pluralrules": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/intl-pluralrules/-/intl-pluralrules-2.0.1.tgz",
+      "integrity": "sha512-astxTLzIdXPeN0K9Rumi6LfMpm3rvNO0iJE+h/k8Kr/is+wPbRe4ikyDjlLr6VTh/mEfNv8RjN+gu3KwDiuhqg==",
+      "license": "ISC"
     },
     "node_modules/invariant": {
       "version": "2.2.4",

--- a/OwnTube.tv/package.json
+++ b/OwnTube.tv/package.json
@@ -41,6 +41,7 @@
     "expo-screen-orientation": "~7.0.5",
     "expo-status-bar": "~1.12.1",
     "i18next": "^23.11.5",
+    "intl-pluralrules": "^2.0.1",
     "jest-expo": "~51.0.3",
     "patch-package": "^8.0.0",
     "react": "18.2.0",

--- a/OwnTube.tv/screens/VideoScreen/index.tsx
+++ b/OwnTube.tv/screens/VideoScreen/index.tsx
@@ -31,6 +31,7 @@ export const VideoScreen = () => {
         category: data.category,
         description: data.description,
         duration: data.duration,
+        channel: data.channel,
       };
 
       updateHistory({ data: updateData });

--- a/OwnTube.tv/utils/common.ts
+++ b/OwnTube.tv/utils/common.ts
@@ -1,13 +1,4 @@
-import { Dimensions } from "react-native";
 import { Channel, GetVideosVideo } from "../api/models";
-
-export const getThumbnailDimensions = () => {
-  const screenWidth = Dimensions.get("window").width;
-  const width = screenWidth * 0.25;
-  const height = width * 0.6 + 50;
-
-  return { width, height };
-};
 
 export const capitalize = (input: string) => {
   return input.charAt(0).toUpperCase() + input.slice(1);


### PR DESCRIPTION
## 🚀 Description

This PR adds video thumbnail layout according to design. Also, for correct pluralization formatting on mobile, added a polyfill.

## 📄 Motivation and Context

#125 

## 🧪 How Has This Been Tested?

all platforms

## 📷 Screenshots (if appropriate)

<img width="453" alt="image" src="https://github.com/user-attachments/assets/151af21e-853b-4812-b6d0-d224a032823a">


## 📦 Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist (copied from README)

- [x] Squash your changes into a single clear and thoroughly descriptive commit, split changes into multiple commits only when it contributes to readability
- [x] Reference the GitHub issue that you are contributing on in your commit title or body
- [x] Sign your commits, as this is required by the automated GitHub PR checks
- [x] Ensure that the changes adhere to the project code style and formatting rules by running `npx eslint .` and `npx prettier --check ../` from the `./OwnTube.tv/` directory (without errors/warnings)
- [x] Include links and illustrations in your pull request to make it easy to review
- [x] Request a review by @mykhailodanilenko, @ar9708 and @mblomdahl
