### PR TITLE
Add "leave instance" button to settings modal

### DIFF
--- a/OwnTube.tv/components/VideoControlsOverlay/components/modals/Settings.tsx
+++ b/OwnTube.tv/components/VideoControlsOverlay/components/modals/Settings.tsx
@@ -1,23 +1,47 @@
 import Animated, { SlideInUp, SlideOutUp } from "react-native-reanimated";
 import { ModalContainer } from "../../../ModalContainer";
-import { ScrollView, StyleSheet } from "react-native";
+import { ScrollView, StyleSheet, View } from "react-native";
 import { DeviceCapabilities } from "../../../DeviceCapabilities";
 import { Spacer } from "../../../shared/Spacer";
 import { spacing } from "../../../../theme";
-import { Checkbox, Picker, Separator } from "../../../shared";
+import { Button, Checkbox, Picker, Separator } from "../../../shared";
 import { useAppConfigContext } from "../../../../contexts";
 import { useSelectLocale } from "../../../../hooks";
 import { LANGUAGE_OPTIONS } from "../../../../i18n";
 import { useTheme } from "@react-navigation/native";
+import { useGlobalSearchParams, useRouter } from "expo-router";
+import { Typography } from "../../../Typography";
+import { RootStackParams } from "../../../../app/_layout";
+import { writeToAsyncStorage } from "../../../../utils";
+import { STORAGE } from "../../../../types";
+import { useQueryClient } from "@tanstack/react-query";
+import { useMemo } from "react";
+import { PeertubeInstance } from "../../../../api/models";
 
 interface SettingsProps {
   onClose: () => void;
 }
 
 export const Settings = ({ onClose }: SettingsProps) => {
+  const { backend } = useGlobalSearchParams<RootStackParams["index"]>();
   const { isDebugMode, setIsDebugMode } = useAppConfigContext();
   const { currentLang, handleChangeLang, t } = useSelectLocale();
-  const { dark: isDarkTheme } = useTheme();
+  const { dark: isDarkTheme, colors } = useTheme();
+  const router = useRouter();
+  const queryClient = useQueryClient();
+
+  const instanceName = useMemo(() => {
+    const instanceInfo = queryClient.getQueryData<{ instance: PeertubeInstance }>(["instance", backend]);
+
+    return instanceInfo?.instance?.name;
+  }, [queryClient, backend]);
+
+  const handleLeaveInstance = () => {
+    writeToAsyncStorage(STORAGE.DATASOURCE, "").then(() => {
+      onClose();
+      router.navigate("/");
+    });
+  };
 
   return (
     <Animated.View entering={SlideInUp} exiting={SlideOutUp} style={styles.animatedContainer} pointerEvents="box-none">
@@ -37,6 +61,21 @@ export const Settings = ({ onClose }: SettingsProps) => {
           />
           <Spacer height={spacing.xl} />
           <Checkbox checked={isDebugMode} onChange={setIsDebugMode} label={t("debugLogging")} />
+          <Spacer height={spacing.xl} />
+          <Separator />
+          <Spacer height={spacing.xl} />
+          <View style={{ alignSelf: "flex-start" }}>
+            <Button
+              onPress={handleLeaveInstance}
+              contrast="none"
+              icon="Exit"
+              text={t("leaveInstance", { instance: instanceName })}
+            />
+          </View>
+          <Spacer height={spacing.lg} />
+          <Typography color={colors.themeDesaturated500} fontWeight="Regular" fontSize="sizeXS">
+            {t("leaveInstanceDescription")}
+          </Typography>
         </ScrollView>
       </ModalContainer>
     </Animated.View>

--- a/OwnTube.tv/locales/en.json
+++ b/OwnTube.tv/locales/en.json
@@ -70,6 +70,8 @@
   "recentlyWatched": "Recently watched",
   "visitChannel": "Visit channel",
   "viewAll": "View all",
+  "leaveInstance": "Leave {{instance}}",
+  "leaveInstanceDescription": "Leave the current site and return to OwnTubes site overview page",
   "errors": {
     "failedToFetchInstances": "Failed to fetch instances: {{error}}",
     "max100VideosPerChunk": "The maximum number of videos to fetch in a single request is 100",

--- a/OwnTube.tv/locales/ru.json
+++ b/OwnTube.tv/locales/ru.json
@@ -54,6 +54,9 @@
   "copy": "Копировать",
   "linkCopied": "Скопировано!",
   "startAt": "Начать с",
+  "welcomeText": "Добро пожаловать на OwnTube!",
+  "welcomeDescriptionText": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut laoreet, nisl dignissim gravida placerat, nunc nibh lacinia tortor faucibus ipsum.",
+  "exploreVideoSites": "Просмотреть видео-сайты",
   "views": "{{count}} просмотров",
   "views_zero": "{{count}} просмотров",
   "views_one": "{{count}} просмотр",
@@ -67,6 +70,8 @@
   "recentlyWatched": "Недавно просмотренные",
   "visitChannel": "Посетить канал",
   "viewAll": "Просмотреть все",
+  "leaveInstance": "Покинуть {{instance}}",
+  "leaveInstanceDescription": "Покинуть текущий сайт и вернуться к странице обзора сайтов OwnTube",
   "errors": {
     "failedToFetchInstances": "Не удалось получить экземпляры: {{error}}",
     "max100VideosPerChunk": "Максимальное количество видео для одного запроса - 100",

--- a/OwnTube.tv/locales/uk.json
+++ b/OwnTube.tv/locales/uk.json
@@ -54,6 +54,9 @@
   "copy": "Копіювати",
   "linkCopied": "Скопійовано!",
   "startAt": "Почати з",
+  "welcomeText": "Ласкаво просимо до OwnTube!",
+  "welcomeDescriptionText": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut laoreet, nisl dignissim gravida placerat, nunc nibh lacinia tortor faucibus ipsum.",
+  "exploreVideoSites": "Переглянути відео-сайти",
   "views": "{{count}} переглядів",
   "views_zero": "{{count}} переглядів",
   "views_one": "{{count}} перегляд",
@@ -67,6 +70,8 @@
   "recentlyWatched": "Недавно переглянуті",
   "visitChannel": "Відвідати канал",
   "viewAll": "Переглянути все",
+  "leaveInstance": "Покинути {{instance}}",
+  "leaveInstanceDescription": "Покинути поточний сайт і повернутись до сторінки огляду сайтів OwnTube",
   "errors": {
     "failedToFetchInstances": "Не вдалося отримати інстанції: {{error}}",
     "max100VideosPerChunk": "Максимальна кількість відео для одного запиту - 100",


### PR DESCRIPTION
## 🚀 Description

This PR adds a "Leave X instance" button to the Settings modal which redirects to the landing page and erases the selected instance from storage.

## 📄 Motivation and Context

closes #134 

## 📷 Screenshots (if appropriate)

<img width="513" alt="image" src="https://github.com/user-attachments/assets/23695102-5fba-4723-8397-cc2e5fb843e9">

## 📦 Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist (copied from README)

- [x] Squash your changes into a single clear and thoroughly descriptive commit, split changes into multiple commits only when it contributes to readability
- [x] Reference the GitHub issue that you are contributing on in your commit title or body
- [x] Sign your commits, as this is required by the automated GitHub PR checks
- [x] Ensure that the changes adhere to the project code style and formatting rules by running `npx eslint .` and `npx prettier --check ../` from the `./OwnTube.tv/` directory (without errors/warnings)
- [x] Include links and illustrations in your pull request to make it easy to review
- [x] Request a review by @mykhailodanilenko, @ar9708 and @mblomdahl
