### PR TITLE
Playlists finishing (#138)

### DIFF
--- a/OwnTube.tv/api/constants.ts
+++ b/OwnTube.tv/api/constants.ts
@@ -22,4 +22,5 @@ export enum QUERY_KEYS {
   categories = "categories",
   playlists = "playlists",
   playlistVideos = "playlistVideos",
+  playlistInfo = "playlistInfo",
 }

--- a/OwnTube.tv/api/playlistsApi.ts
+++ b/OwnTube.tv/api/playlistsApi.ts
@@ -1,4 +1,4 @@
-import { VideoPlaylist } from "@peertube/peertube-types";
+import { VideoPlaylist, VideosCommonQuery } from "@peertube/peertube-types";
 import { Video } from "@peertube/peertube-types/peertube-models/videos/video.model";
 import { GetVideosVideo } from "./models";
 import { AxiosInstanceBasedApi } from "./axiosInstance";
@@ -44,13 +44,13 @@ export class PlaylistsApi extends AxiosInstanceBasedApi {
   async getPlaylistVideos(
     baseURL: string,
     playlistId: number,
-    queryParams?: { count: number },
+    queryParams?: VideosCommonQuery,
   ): Promise<{ data: GetVideosVideo[]; total: number }> {
     try {
       const response = await this.instance.get<{ data: Array<{ video: Video }>; total: number }>(
         `video-playlists/${playlistId}/videos`,
         {
-          params: { sort: "-originallyPublishedAt", ...(queryParams || {}) },
+          params: { ...(queryParams || {}) },
           baseURL: `https://${baseURL}/api/v1`,
         },
       );
@@ -74,6 +74,25 @@ export class PlaylistsApi extends AxiosInstanceBasedApi {
       };
     } catch (error: unknown) {
       return handleAxiosErrorWithRetry(error, "playlist videos");
+    }
+  }
+
+  /**
+   * Get info on an instance playlist
+   *
+   * @param [baseURL] - Selected instance url
+   * @param [playlistId] - Playlist ID
+   * @returns Playlist info
+   */
+  async getPlaylistInfo(baseURL: string, playlistId: number): Promise<VideoPlaylist> {
+    try {
+      const response = await this.instance.get<VideoPlaylist>(`video-playlists/${playlistId}`, {
+        baseURL: `https://${baseURL}/api/v1`,
+      });
+
+      return response.data;
+    } catch (error: unknown) {
+      return handleAxiosErrorWithRetry(error, "playlist info");
     }
   }
 }

--- a/OwnTube.tv/app/(home)/playlist.tsx
+++ b/OwnTube.tv/app/(home)/playlist.tsx
@@ -1,0 +1,23 @@
+import { useTranslation } from "react-i18next";
+import { Platform } from "react-native";
+import Head from "expo-router/head";
+import { Playlist } from "../../screens";
+
+export default function playlists() {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      {Platform.select({
+        default: null,
+        web: (
+          <Head>
+            <title>{t("playlist")}</title>
+            <meta name="description" content={`${t("appName")} ${t("playlist").toLowerCase()}`} />
+          </Head>
+        ),
+      })}
+      <Playlist />
+    </>
+  );
+}

--- a/OwnTube.tv/app/_layout.tsx
+++ b/OwnTube.tv/app/_layout.tsx
@@ -85,6 +85,7 @@ const RootStack = () => {
           <Drawer.Screen name={`(home)/${ROUTES.CATEGORIES}`} />
           <Drawer.Screen name={`(home)/${ROUTES.CATEGORY}`} />
           <Drawer.Screen name={`(home)/${ROUTES.PLAYLISTS}`} />
+          <Drawer.Screen name={`(home)/${ROUTES.PLAYLIST}`} />
         </Drawer>
         <Toast />
         <FullScreenModal onBackdropPress={() => toggleModal?.(false)} isVisible={isModalOpen}>
@@ -163,4 +164,5 @@ export type RootStackParams = {
   [ROUTES.CHANNEL_CATEGORY]: { backend: string; channel: string; category: string };
   [ROUTES.CATEGORIES]: { backend: string };
   [ROUTES.CATEGORY]: { backend: string; category: string };
+  [ROUTES.PLAYLIST]: { backend: string; playlist: string };
 };

--- a/OwnTube.tv/components/CategoryView.tsx
+++ b/OwnTube.tv/components/CategoryView.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { useGetVideosQuery } from "../api";
 import { ROUTES } from "../types";
 import { useLocalSearchParams } from "expo-router";
+import { getAvailableVidsString } from "../utils";
 
 interface CategoryViewProps {
   category: { name: string; id: number };
@@ -29,8 +30,8 @@ export const CategoryView = ({ category }: CategoryViewProps) => {
     <VideoGrid
       isLoading={isFetching}
       headerLink={{
-        text: `${t("viewAll")} (${Number(data?.total)})`,
-        href: { pathname: ROUTES.CATEGORY, params: { backend, category: category.id } },
+        text: t("viewAll") + getAvailableVidsString(data?.total),
+        href: { pathname: `/${ROUTES.CATEGORY}`, params: { backend, category: category.id } },
       }}
       title={category.name}
       data={data?.data}

--- a/OwnTube.tv/components/ChannelView.tsx
+++ b/OwnTube.tv/components/ChannelView.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 import { ROUTES } from "../types";
 import { useLocalSearchParams } from "expo-router";
 import { RootStackParams } from "../app/_layout";
+import { getAvailableVidsString } from "../utils";
 
 interface ChannelViewProps {
   channel: VideoChannel;
@@ -23,8 +24,8 @@ export const ChannelView = ({ channel }: ChannelViewProps) => {
     <VideoGrid
       isLoading={isFetching}
       headerLink={{
-        text: `${t("visitChannel")} (${Number(data?.total)})`,
-        href: { pathname: ROUTES.CHANNEL, params: { backend, channel: channel.name } },
+        text: t("visitChannel") + getAvailableVidsString(data?.total),
+        href: { pathname: `/${ROUTES.CHANNEL}`, params: { backend, channel: channel.name } },
       }}
       variant="channel"
       key={channel.id}

--- a/OwnTube.tv/components/VideoGrid/VideoGridContent.tsx
+++ b/OwnTube.tv/components/VideoGrid/VideoGridContent.tsx
@@ -1,0 +1,81 @@
+import { Platform, StyleSheet, View } from "react-native";
+import { spacing } from "../../theme";
+import VideoGridCardLoader from "../loaders/VideoGridCardLoader";
+import { VideoGridCard } from "../VideoGridCard";
+import { VideoGridProps } from "./VideoGrid";
+
+interface VideoGridContentProps extends Pick<VideoGridProps, "data" | "variant"> {
+  isLoading?: boolean;
+  backend?: string;
+}
+
+export const VideoGridContent = ({ isLoading, data = [], variant, backend }: VideoGridContentProps) => {
+  return (
+    <View
+      style={Platform.select({
+        web: { $$css: true, _: "grid-container" },
+        default: {
+          flex: 1,
+          flexDirection: "row",
+          flexWrap: "wrap",
+          gap: spacing.xl,
+          alignItems: "flex-start",
+        },
+      })}
+    >
+      {isLoading
+        ? [...Array(4)].map((_, index) => {
+            return (
+              <View
+                key={index}
+                style={Platform.select({
+                  web: styles.gridItemWeb,
+                  default: styles.loaderGridItemNonWeb,
+                })}
+              >
+                <VideoGridCardLoader />
+              </View>
+            );
+          })
+        : data.map((video) => {
+            return (
+              <View
+                key={video.uuid}
+                style={Platform.select({
+                  web: styles.gridItemWeb,
+                  default: styles.gridItemNonWeb,
+                })}
+              >
+                <VideoGridCard
+                  backend={variant === "history" && "backend" in video ? video.backend : backend}
+                  video={video}
+                />
+              </View>
+            );
+          })}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  gridItemNonWeb: {
+    alignSelf: "flex-start",
+    flex: 1,
+    height: "auto",
+    maxHeight: "100%",
+    maxWidth: "100%",
+    minWidth: "100%",
+    width: "100%",
+  },
+  gridItemWeb: { flex: 1 },
+  loaderGridItemNonWeb: {
+    aspectRatio: 1.145,
+    flexDirection: "row",
+    flex: 0,
+    justifyContent: "flex-start",
+    maxHeight: "100%",
+    maxWidth: "100%",
+    minWidth: "100%",
+    width: "100%",
+  },
+});

--- a/OwnTube.tv/components/VideoGrid/VideoListContent.tsx
+++ b/OwnTube.tv/components/VideoGrid/VideoListContent.tsx
@@ -1,0 +1,32 @@
+import { VideoGridProps } from "./VideoGrid";
+import { StyleSheet, View } from "react-native";
+import { VideoListItem } from "../VideoListItem";
+import { spacing } from "../../theme";
+import { Loader } from "../Loader";
+
+interface VideoListContentProps extends Pick<VideoGridProps, "data" | "variant"> {
+  isLoading?: boolean;
+  backend?: string;
+}
+
+export const VideoListContent = ({ isLoading, data = [], variant, backend }: VideoListContentProps) => {
+  if (isLoading) {
+    return <Loader />;
+  }
+
+  return (
+    <View style={styles.container}>
+      {data.map((video) => (
+        <VideoListItem
+          key={video.uuid}
+          video={video}
+          backend={variant === "history" && "backend" in video ? video.backend : backend}
+        />
+      ))}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { gap: spacing.xl, maxWidth: 900 },
+});

--- a/OwnTube.tv/components/VideoListItem.tsx
+++ b/OwnTube.tv/components/VideoListItem.tsx
@@ -12,13 +12,21 @@ import { useMemo } from "react";
 import { ChannelLink } from "./ChannelLink";
 import { IcoMoonIcon } from "./IcoMoonIcon";
 import { LANGUAGE_OPTIONS } from "../i18n";
+import { GetVideosVideo } from "../api/models";
 
-interface ViewHistoryListItemProps {
-  video: ViewHistoryEntry;
-  handleDeleteFromHistory: () => void;
+interface VideoListItemProps extends Partial<Pick<ViewHistoryEntry, "lastViewedAt" | "timestamp">> {
+  video: GetVideosVideo;
+  handleDeleteFromHistory?: () => void;
+  backend?: string;
 }
 
-export const ViewHistoryListItem = ({ video, handleDeleteFromHistory }: ViewHistoryListItemProps) => {
+export const VideoListItem = ({
+  video,
+  handleDeleteFromHistory,
+  backend,
+  timestamp,
+  lastViewedAt,
+}: VideoListItemProps) => {
   const { t, i18n } = useTranslation();
   const { colors } = useTheme();
   const { isHovered, toggleHovered } = useHoverState();
@@ -26,11 +34,15 @@ export const ViewHistoryListItem = ({ video, handleDeleteFromHistory }: ViewHist
   const videoHref = useMemo(() => {
     return {
       pathname: `/${ROUTES.VIDEO}`,
-      params: { id: video.uuid, backend: video.backend, timestamp: video.timestamp },
+      params: { id: video.uuid, backend, timestamp },
     };
-  }, [video]);
+  }, [video, backend, timestamp]);
 
   const deleteBtn = useMemo(() => {
+    if (!handleDeleteFromHistory) {
+      return null;
+    }
+
     return (
       <Pressable onPress={handleDeleteFromHistory} style={{ padding: 6 }}>
         <IcoMoonIcon color={colors.theme950} name="Trash" size={24} />
@@ -44,14 +56,14 @@ export const ViewHistoryListItem = ({ video, handleDeleteFromHistory }: ViewHist
         <VideoThumbnail
           imageDimensions={{ width: isDesktop ? 328 : 128, height: isDesktop ? 102 : 72 }}
           video={video}
-          backend={video.backend}
+          backend={backend}
           key={video.uuid}
-          timestamp={video.timestamp}
+          timestamp={timestamp}
         />
       </Link>
       <View style={styles.infoContainer}>
         <View style={styles.textContainer}>
-          {video.lastViewedAt && (
+          {lastViewedAt && (
             <View style={{ flexDirection: "row", justifyContent: "space-between" }}>
               <Typography
                 fontWeight="Medium"
@@ -59,7 +71,7 @@ export const ViewHistoryListItem = ({ video, handleDeleteFromHistory }: ViewHist
                 color={colors.themeDesaturated500}
                 style={{ maxWidth: isDesktop ? null : 150 }}
               >
-                {t("lastWatched", { lastWatched: format(video.lastViewedAt, "yyyy-MM-dd HH:mm") })}
+                {t("lastWatched", { lastWatched: format(lastViewedAt, "yyyy-MM-dd HH:mm") })}
               </Typography>
               {!isDesktop && deleteBtn}
             </View>
@@ -78,7 +90,7 @@ export const ViewHistoryListItem = ({ video, handleDeleteFromHistory }: ViewHist
             </Pressable>
           </Link>
           <ChannelLink
-            href={{ pathname: ROUTES.CHANNEL, params: { backend: video.backend, channel: video.channel?.name } }}
+            href={{ pathname: ROUTES.CHANNEL, params: { backend: backend, channel: video.channel?.name } }}
             text={video.channel?.displayName}
           />
           <Typography fontSize="sizeXS" fontWeight="Medium" color={colors.themeDesaturated500}>

--- a/OwnTube.tv/components/ViewHistory.tsx
+++ b/OwnTube.tv/components/ViewHistory.tsx
@@ -3,7 +3,7 @@ import { SectionList, StyleSheet, View } from "react-native";
 import { Loader } from "./Loader";
 import { Spacer } from "./shared/Spacer";
 import { Typography } from "./Typography";
-import { ViewHistoryListItem } from "./ViewHistoryListItem";
+import { VideoListItem } from "./VideoListItem";
 import { useTranslation } from "react-i18next";
 import { useCallback, useMemo } from "react";
 import { Screen } from "../layouts";
@@ -69,7 +69,13 @@ export const ViewHistory = () => {
 
   const renderItem = useCallback(
     ({ item }: { item: ViewHistoryEntry }) => (
-      <ViewHistoryListItem handleDeleteFromHistory={() => deleteVideoFromHistory(item.uuid)} video={item} />
+      <VideoListItem
+        handleDeleteFromHistory={() => deleteVideoFromHistory(item.uuid)}
+        video={item}
+        backend={item.backend}
+        timestamp={item.timestamp}
+        lastViewedAt={item.lastViewedAt}
+      />
     ),
     [deleteVideoFromHistory],
   );

--- a/OwnTube.tv/components/index.ts
+++ b/OwnTube.tv/components/index.ts
@@ -25,3 +25,4 @@ export * from "./VideoGrid";
 export * from "./ChannelView";
 export * from "./CategoryView";
 export * from "./BuildInfo";
+export * from "./VideoListItem";

--- a/OwnTube.tv/locales/en.json
+++ b/OwnTube.tv/locales/en.json
@@ -80,5 +80,7 @@
   "playlistsPageTitle": "Playlists",
   "currentBuild": "Current build:",
   "cancel": "Cancel",
-  "otherSites": "Other sites"
+  "otherSites": "Other sites",
+  "playlist": "Playlist",
+  "viewFullPlaylist": "View full playlist"
 }

--- a/OwnTube.tv/locales/ru.json
+++ b/OwnTube.tv/locales/ru.json
@@ -77,6 +77,8 @@
   "viewAll": "Просмотреть все",
   "leaveInstance": "Покинуть {{instance}}",
   "leaveInstanceDescription": "Покинуть текущий сайт и вернуться к странице обзора сайтов OwnTube",
+  "playlist": "Плейлист",
+  "viewFullPlaylist": "Просмотреть плейлист полностью",
   "playlistsPageTitle": "Плейлисты",
   "currentBuild": "Текущая сборка:",
   "cancel": "Отмена",

--- a/OwnTube.tv/locales/uk.json
+++ b/OwnTube.tv/locales/uk.json
@@ -77,6 +77,8 @@
   "viewAll": "Переглянути все",
   "leaveInstance": "Покинути {{instance}}",
   "leaveInstanceDescription": "Покинути поточний сайт і повернутись до сторінки огляду сайтів OwnTube",
+  "playlist": "Плейліст",
+  "viewFullPlaylist": "Переглянути плейліст повністю",
   "playlistsPageTitle": "Плейлісти",
   "currentBuild": "Поточна збірка:",
   "cancel": "Скасувати",

--- a/OwnTube.tv/screens/ChannelScreen/components/CategoryView.tsx
+++ b/OwnTube.tv/screens/ChannelScreen/components/CategoryView.tsx
@@ -4,6 +4,7 @@ import { VideoGrid } from "../../../components";
 import { ROUTES } from "../../../types";
 import { useLocalSearchParams } from "expo-router";
 import { RootStackParams } from "../../../app/_layout";
+import { getAvailableVidsString } from "../../../utils";
 
 interface CategoryViewProps {
   category: { name: string; id: number };
@@ -23,8 +24,11 @@ export const CategoryView = ({ category, channelHandle }: CategoryViewProps) => 
     <VideoGrid
       isLoading={isFetching}
       headerLink={{
-        text: `${t("viewAll")} (${Number(data?.total)})`,
-        href: { pathname: ROUTES.CHANNEL_CATEGORY, params: { backend, channel: channelHandle, category: category.id } },
+        text: t("viewAll") + getAvailableVidsString(data?.total),
+        href: {
+          pathname: `/${ROUTES.CHANNEL_CATEGORY}`,
+          params: { backend, channel: channelHandle, category: category.id },
+        },
       }}
       title={category.name}
       data={data?.data}

--- a/OwnTube.tv/screens/HomeScreen/index.tsx
+++ b/OwnTube.tv/screens/HomeScreen/index.tsx
@@ -37,7 +37,7 @@ export const HomeScreen = () => {
       <LatestVideosView />
       {historyData.length > 0 && (
         <VideoGrid
-          headerLink={{ text: t("viewHistory"), href: { pathname: ROUTES.HISTORY, params: { backend } } }}
+          headerLink={{ text: t("viewHistory"), href: { pathname: `/${ROUTES.HISTORY}`, params: { backend } } }}
           title={t("recentlyWatched")}
           icon="History"
           data={historyData}

--- a/OwnTube.tv/screens/Playlist/index.tsx
+++ b/OwnTube.tv/screens/Playlist/index.tsx
@@ -1,0 +1,35 @@
+import { useGetPlaylistInfoQuery, useInfiniteGetPlaylistVideosQuery } from "../../api";
+import { useLocalSearchParams } from "expo-router";
+import { RootStackParams } from "../../app/_layout";
+import { ROUTES } from "../../types";
+import { Loader, VideoGrid } from "../../components";
+import { useMemo } from "react";
+import { Screen } from "../../layouts";
+
+export const Playlist = () => {
+  const { playlist } = useLocalSearchParams<RootStackParams[ROUTES.PLAYLIST]>();
+  const { fetchNextPage, data, hasNextPage, isLoading, isFetchingNextPage } = useInfiniteGetPlaylistVideosQuery(
+    Number(playlist),
+  );
+  const { data: playlistInfo, isFetching: isFetchingPlaylistInfo } = useGetPlaylistInfoQuery(Number(playlist));
+  const videos = useMemo(() => {
+    return data?.pages?.flatMap(({ data }) => data.flat());
+  }, [data]);
+
+  if (isFetchingPlaylistInfo || isLoading) {
+    return <Loader />;
+  }
+
+  return (
+    <Screen style={{ padding: 0 }}>
+      <VideoGrid
+        presentation="list"
+        isLoading={isLoading}
+        data={videos}
+        title={playlistInfo?.displayName}
+        isLoadingMore={isFetchingNextPage}
+        handleShowMore={hasNextPage ? fetchNextPage : undefined}
+      />
+    </Screen>
+  );
+};

--- a/OwnTube.tv/screens/Playlists/components/PlaylistVideosView.tsx
+++ b/OwnTube.tv/screens/Playlists/components/PlaylistVideosView.tsx
@@ -1,5 +1,9 @@
-import { Loader, VideoGrid } from "../../../components";
+import { VideoGrid } from "../../../components";
 import { useGetPlaylistVideosQuery } from "../../../api";
+import { ROUTES } from "../../../types";
+import { useLocalSearchParams } from "expo-router";
+import { useTranslation } from "react-i18next";
+import { getAvailableVidsString } from "../../../utils";
 
 interface PlaylistVideosViewProps {
   id: number;
@@ -7,11 +11,23 @@ interface PlaylistVideosViewProps {
 }
 
 export const PlaylistVideosView = ({ id, title }: PlaylistVideosViewProps) => {
+  const { backend } = useLocalSearchParams();
   const { data, isFetching } = useGetPlaylistVideosQuery(id);
+  const { t } = useTranslation();
 
-  if (isFetching) {
-    return <Loader />;
+  if ((!data?.data?.length || !data?.total) && !isFetching) {
+    return null;
   }
 
-  return <VideoGrid title={title} data={data?.data} />;
+  return (
+    <VideoGrid
+      isLoading={isFetching}
+      title={title}
+      data={data?.data}
+      headerLink={{
+        text: t("viewFullPlaylist") + getAvailableVidsString(data?.total),
+        href: { pathname: `/${ROUTES.PLAYLIST}`, params: { backend, playlist: id } },
+      }}
+    />
+  );
 };

--- a/OwnTube.tv/screens/Playlists/index.tsx
+++ b/OwnTube.tv/screens/Playlists/index.tsx
@@ -11,7 +11,7 @@ export const Playlists = () => {
   }
 
   return (
-    <Screen>
+    <Screen style={{ padding: 0 }}>
       {playlists?.data?.map(({ id, displayName }) => <PlaylistVideosView title={displayName} key={id} id={id} />)}
     </Screen>
   );

--- a/OwnTube.tv/screens/index.ts
+++ b/OwnTube.tv/screens/index.ts
@@ -7,3 +7,4 @@ export * from "./ChannelsScreen";
 export * from "./Playlists";
 export * from "./CategoriesScreen";
 export * from "./CategoryScreen";
+export * from "./Playlist";

--- a/OwnTube.tv/types.ts
+++ b/OwnTube.tv/types.ts
@@ -21,6 +21,7 @@ export enum ROUTES {
   CATEGORIES = "categories",
   CATEGORY = "category",
   PLAYLISTS = "playlists",
+  PLAYLIST = "playlist",
 }
 
 export interface Category {

--- a/OwnTube.tv/utils/common.ts
+++ b/OwnTube.tv/utils/common.ts
@@ -1,3 +1,7 @@
 export const capitalize = (input: string) => {
   return input.charAt(0).toUpperCase() + input.slice(1);
 };
+
+export const getAvailableVidsString = (count?: number) => {
+  return ` (${count ?? "?"})`;
+};


### PR DESCRIPTION
## 🚀 Description

This PR puts playlists in line with design docs, also adds ability to switch between list and grid views on desktop (on mobile both options inevitably become lists) - can be checked out in single playlist view. See deployed to https://mykhailodanilenko.github.io/web-client/

## 📄 Motivation and Context

#138 

## 🧪 How Has This Been Tested?

Web and mobile

## 📷 Screenshots (if appropriate)

![image](https://github.com/user-attachments/assets/6e9ae2d4-4284-4819-aedc-9fca360c2090)


## 📦 Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist (copied from README)

- [x] Squash your changes into a single clear and thoroughly descriptive commit, split changes into multiple commits only when it contributes to readability
- [x] Reference the GitHub issue that you are contributing on in your commit title or body
- [x] Sign your commits, as this is required by the automated GitHub PR checks
- [x] Ensure that the changes adhere to the project code style and formatting rules by running `npx eslint .` and `npx prettier --check ../` from the `./OwnTube.tv/` directory (without errors/warnings)
- [x] Include links and illustrations in your pull request to make it easy to review
- [x] Request a review by @mykhailodanilenko, @ar9708 and @mblomdahl
