### PR TITLE
Fix condition in customization setup

### DIFF
--- a/.github/workflows/deploy-static-main.yml
+++ b/.github/workflows/deploy-static-main.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Check for Customization Variables
         id: check_customizations
         run: |
-          if [[ -n ${{ vars.CLIENT_CUSTOMIZATIONS_REPO }} && -n ${{ vars.CLIENT_CUSTOMIZATIONS_FILE }} ]]; then
+          if [[ -n "${{ vars.CLIENT_CUSTOMIZATIONS_REPO }}" && -n "${{ vars.CLIENT_CUSTOMIZATIONS_FILE }}" ]]; then
             echo "should_run_customizations=true" >> $GITHUB_OUTPUT
           else
             echo "should_run_customizations=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## 🚀 Description

This PR aims to fix an issue with getting customization variables when the environment is unset. Example in https://github.com/mykhailodanilenko/web-client/actions/runs/11679600112, this run happened when the environment was cleared

## 📄 Motivation and Context

#205 

## 📦 Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist (copied from README)

- [x] Squash your changes into a single clear and thoroughly descriptive commit, split changes into multiple commits only when it contributes to readability
- [x] Reference the GitHub issue that you are contributing on in your commit title or body
- [x] Sign your commits, as this is required by the automated GitHub PR checks
- [x] Ensure that the changes adhere to the project code style and formatting rules by running `npx eslint .` and `npx prettier --check ../` from the `./OwnTube.tv/` directory (without errors/warnings)
- [x] Include links and illustrations in your pull request to make it easy to review
- [x] Request a review by @mykhailodanilenko, @ar9708 and @mblomdahl
