### PR TITLE
Fix android thumbnails + fix grids on non-web

### DIFF
--- a/OwnTube.tv/components/VideoGrid/VideoGridContent.tsx
+++ b/OwnTube.tv/components/VideoGrid/VideoGridContent.tsx
@@ -3,13 +3,22 @@ import { spacing } from "../../theme";
 import VideoGridCardLoader from "../loaders/VideoGridCardLoader";
 import { VideoGridCard } from "../VideoGridCard";
 import { VideoGridProps } from "./VideoGrid";
+import { useMemo, useState } from "react";
 
 interface VideoGridContentProps extends Pick<VideoGridProps, "data" | "variant"> {
   isLoading?: boolean;
   backend?: string;
 }
 
+const MINIMUM_COLUMN_WIDTH = 277;
+
 export const VideoGridContent = ({ isLoading, data = [], variant, backend }: VideoGridContentProps) => {
+  const [containerWidth, setContainerWidth] = useState(0);
+  const columnWidth = useMemo(() => {
+    const numCols = Math.floor(containerWidth / MINIMUM_COLUMN_WIDTH) || 1;
+    return (containerWidth - (numCols - 1) * spacing.xl) / numCols;
+  }, [containerWidth]);
+
   return (
     <View
       style={Platform.select({
@@ -22,6 +31,9 @@ export const VideoGridContent = ({ isLoading, data = [], variant, backend }: Vid
           alignItems: "flex-start",
         },
       })}
+      onLayout={(e) => {
+        setContainerWidth(e.nativeEvent.layout.width);
+      }}
     >
       {isLoading
         ? [...Array(4)].map((_, index) => {
@@ -41,9 +53,10 @@ export const VideoGridContent = ({ isLoading, data = [], variant, backend }: Vid
             return (
               <View
                 key={video.uuid}
+                // @ts-expect-error wrong typings on Platform.select and style prop
                 style={Platform.select({
                   web: styles.gridItemWeb,
-                  default: styles.gridItemNonWeb,
+                  default: { ...styles.gridItemNonWeb, width: columnWidth },
                 })}
               >
                 <VideoGridCard
@@ -60,12 +73,7 @@ export const VideoGridContent = ({ isLoading, data = [], variant, backend }: Vid
 const styles = StyleSheet.create({
   gridItemNonWeb: {
     alignSelf: "flex-start",
-    flex: 1,
     height: "auto",
-    maxHeight: "100%",
-    maxWidth: "100%",
-    minWidth: "100%",
-    width: "100%",
   },
   gridItemWeb: { flex: 1 },
   loaderGridItemNonWeb: {

--- a/OwnTube.tv/components/VideoGridCard.tsx
+++ b/OwnTube.tv/components/VideoGridCard.tsx
@@ -11,6 +11,7 @@ import { ChannelLink } from "./ChannelLink";
 import { formatDistanceToNow } from "date-fns";
 import { useTranslation } from "react-i18next";
 import { LANGUAGE_OPTIONS } from "../i18n";
+import { useState } from "react";
 
 interface VideoGridCardProps {
   video: GetVideosVideo;
@@ -24,16 +25,20 @@ export const VideoGridCard = ({ video, backend }: VideoGridCardProps) => {
   const { t, i18n } = useTranslation();
   const { getViewHistoryEntryByUuid } = useViewHistory({ enabled: false });
   const { timestamp } = getViewHistoryEntryByUuid(video.uuid) || {};
+  const [containerWidth, setContainerWidth] = useState(0);
 
   return (
     <View style={styles.container}>
       <Pressable style={styles.pressableContainer} onPress={null} onHoverIn={toggleHovered} onHoverOut={toggleHovered}>
         <Link
+          onLayout={(e) => {
+            setContainerWidth(e.nativeEvent.layout.width);
+          }}
           style={styles.linkWrapper}
           href={{ pathname: `/${ROUTES.VIDEO}`, params: { id: video.uuid, backend, timestamp } }}
         >
           <VideoThumbnail
-            imageDimensions={{ width: 360, height: 202.5 }}
+            imageDimensions={{ width: containerWidth, height: containerWidth * (9 / 16) }}
             video={video}
             timestamp={timestamp}
             backend={backend}
@@ -41,17 +46,15 @@ export const VideoGridCard = ({ video, backend }: VideoGridCardProps) => {
         </Link>
         <View style={styles.textContainer}>
           <Link href={{ pathname: ROUTES.VIDEO, params: { id: video.uuid, backend } }}>
-            <View>
-              <Typography
-                fontWeight="Medium"
-                color={colors.theme900}
-                fontSize={isDesktop ? "sizeMd" : "sizeSm"}
-                numberOfLines={4}
-                style={{ textDecorationLine: isHovered ? "underline" : undefined }}
-              >
-                {video.name}
-              </Typography>
-            </View>
+            <Typography
+              fontWeight="Medium"
+              color={colors.theme900}
+              fontSize={isDesktop ? "sizeMd" : "sizeSm"}
+              numberOfLines={4}
+              style={{ textDecorationLine: isHovered ? "underline" : undefined }}
+            >
+              {video.name}
+            </Typography>
           </Link>
         </View>
       </Pressable>

--- a/OwnTube.tv/components/VideoThumbnail.tsx
+++ b/OwnTube.tv/components/VideoThumbnail.tsx
@@ -25,7 +25,7 @@ export const VideoThumbnail: FC<VideoThumbnailProps> = ({ video, backend, timest
 
   const imageSource = video.previewPath ? { uri: video.previewPath } : fallback;
 
-  if (!backend) {
+  if (!backend || !imageDimensions.width || !imageDimensions.height) {
     return null;
   }
 
@@ -35,7 +35,7 @@ export const VideoThumbnail: FC<VideoThumbnailProps> = ({ video, backend, timest
         {...imageDimensions}
         resizeMode="cover"
         source={isError ? fallback : imageSource}
-        style={[styles.videoImage, { width: "100%", height: "100%" }]}
+        style={styles.videoImage}
         onError={() => setIsError(true)}
       />
       {!!percentageWatched && percentageWatched > 0 && (


### PR DESCRIPTION
## 🚀 Description

This PR aims to fix video thumbnails on Android platforms + fix grid views on all non-web platforms (previously the grids were 1 giant column if using non web)

## 📄 Motivation and Context

#206 

## 🧪 How Has This Been Tested?

- [x] Web (desktop)
- [x]  Web (mobile)
- [x] Mobile (iOS)
- [x] Mobile (Android)
- [x] TV (Android)
- [x] TV (tvOS)

## 📦 Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist (copied from README)

- [x] Squash your changes into a single clear and thoroughly descriptive commit, split changes into multiple commits only when it contributes to readability
- [x] Reference the GitHub issue that you are contributing on in your commit title or body
- [x] Sign your commits, as this is required by the automated GitHub PR checks
- [x] Ensure that the changes adhere to the project code style and formatting rules by running `npx eslint .` and `npx prettier --check ../` from the `./OwnTube.tv/` directory (without errors/warnings)
- [x] Include links and illustrations in your pull request to make it easy to review
- [x] Request a review by @mykhailodanilenko, @ar9708 and @mblomdahl
