### PR TITLE
Add focus highlight for pressable elements on tv

### DIFF
--- a/OwnTube.tv/components/ChannelLink.tsx
+++ b/OwnTube.tv/components/ChannelLink.tsx
@@ -1,5 +1,5 @@
 import { Link } from "expo-router";
-import { FC } from "react";
+import { FC, useState } from "react";
 import { Typography } from "./Typography";
 import { useTheme } from "@react-navigation/native";
 import { useHoverState } from "../hooks";
@@ -10,17 +10,26 @@ import { ROUTES } from "../types";
 interface ChannelLinkProps {
   href: LinkProps<ROUTES>["href"];
   text: string;
+  enableOnTV?: boolean;
 }
 
-export const ChannelLink: FC<ChannelLinkProps> = ({ href, text }) => {
+export const ChannelLink: FC<ChannelLinkProps> = ({ href, text, enableOnTV = false }) => {
   const { colors } = useTheme();
   const { isHovered, toggleHovered } = useHoverState();
+  const [focused, setFocused] = useState(false);
 
   return (
     <Link href={href} asChild>
-      <Pressable onHoverIn={toggleHovered} onHoverOut={toggleHovered}>
+      <Pressable
+        focusable={enableOnTV}
+        isTVSelectable={enableOnTV}
+        onHoverIn={toggleHovered}
+        onHoverOut={toggleHovered}
+        onFocus={() => setFocused(true)}
+        onBlur={() => setFocused(false)}
+      >
         <Typography
-          style={{ textDecorationLine: isHovered ? "underline" : undefined }}
+          style={{ textDecorationLine: isHovered || focused ? "underline" : undefined }}
           fontSize="sizeSm"
           fontWeight="Medium"
           color={colors.themeDesaturated500}

--- a/OwnTube.tv/components/ErrorTextWithRetry.tsx
+++ b/OwnTube.tv/components/ErrorTextWithRetry.tsx
@@ -15,7 +15,14 @@ export const ErrorTextWithRetry = ({ errorText, refetch }: ErrorTextWithRetryPro
   return (
     <Typography fontSize="sizeSm" fontWeight="Medium" color={colors.themeDesaturated500}>
       {errorText}{" "}
-      <Pressable onPress={refetch}>
+      <Pressable
+        onPress={refetch}
+        style={({ focused }) => ({
+          borderWidth: focused ? 2 : 0,
+          borderColor: colors.theme950,
+          padding: focused ? 0 : 2,
+        })}
+      >
         <Typography
           fontSize="sizeSm"
           fontWeight="Medium"

--- a/OwnTube.tv/components/PlatformCard.tsx
+++ b/OwnTube.tv/components/PlatformCard.tsx
@@ -7,6 +7,7 @@ import { useBreakpoints, useHoverState } from "../hooks";
 import { IcoMoonIcon } from "./IcoMoonIcon";
 import { InstanceLogo } from "./InstanceLogo";
 import { ROUTES } from "../types";
+import { useState } from "react";
 
 interface PlatformCardProps {
   name?: string;
@@ -19,16 +20,23 @@ export const PlatformCard = ({ name, description, hostname, logoUrl }: PlatformC
   const { colors } = useTheme();
   const { isHovered, hoverHandlers } = useHoverState();
   const { isDesktop } = useBreakpoints();
+  const [focused, setFocused] = useState(false);
 
   return (
     <Link href={{ pathname: `/${ROUTES.HOME}`, params: { backend: hostname } }} asChild>
-      <Pressable style={styles.pressableContainer} {...hoverHandlers}>
+      <Pressable
+        style={styles.pressableContainer}
+        onFocus={() => setFocused(true)}
+        onBlur={() => setFocused(false)}
+        {...hoverHandlers}
+      >
         <View
           style={[
             styles.container,
             {
-              padding: isDesktop ? spacing.xl : spacing.lg,
-              borderColor: colors.theme200,
+              borderWidth: focused ? 2 : 1,
+              padding: (isDesktop ? spacing.xl : spacing.lg) - (focused ? 1 : 0),
+              borderColor: focused ? colors.theme950 : colors.theme200,
               backgroundColor: isHovered ? colors.theme200 : colors.theme100,
             },
           ]}
@@ -79,7 +87,6 @@ const styles = StyleSheet.create({
   arrow: { transform: [{ rotate: "180deg" }] },
   container: {
     borderRadius: borderRadius.radiusMd,
-    borderWidth: 1,
     flexDirection: "row",
     flex: 1,
     gap: spacing.lg,

--- a/OwnTube.tv/components/VideoGrid/PresentationSwitch.tsx
+++ b/OwnTube.tv/components/VideoGrid/PresentationSwitch.tsx
@@ -37,7 +37,7 @@ export const PresentationSwitch = ({ presentation, handleSetPresentation }: Pres
 };
 
 const styles = StyleSheet.create({
-  presentationSwitcherButton: { height: 36 },
+  presentationSwitcherButton: { height: 36, paddingVertical: 6 },
   presentationSwitcherContainer: {
     alignSelf: "flex-start",
     borderRadius: 12,

--- a/OwnTube.tv/components/VideoListItem.tsx
+++ b/OwnTube.tv/components/VideoListItem.tsx
@@ -1,5 +1,5 @@
 import { VideoThumbnail } from "./VideoThumbnail";
-import { Pressable, StyleSheet, View } from "react-native";
+import { Pressable, StyleSheet, TVFocusGuideView, View } from "react-native";
 import { Typography } from "./Typography";
 import { format, formatDistanceToNow } from "date-fns";
 import { useBreakpoints, useHoverState, ViewHistoryEntry } from "../hooks";
@@ -10,9 +10,9 @@ import { spacing } from "../theme";
 import { useTheme } from "@react-navigation/native";
 import { useMemo } from "react";
 import { ChannelLink } from "./ChannelLink";
-import { IcoMoonIcon } from "./IcoMoonIcon";
 import { LANGUAGE_OPTIONS } from "../i18n";
 import { GetVideosVideo } from "../api/models";
+import { Button } from "./shared";
 
 interface VideoListItemProps extends Partial<Pick<ViewHistoryEntry, "lastViewedAt" | "timestamp">> {
   video: GetVideosVideo;
@@ -43,26 +43,33 @@ export const VideoListItem = ({
       return null;
     }
 
-    return (
-      <Pressable onPress={handleDeleteFromHistory} style={{ padding: 6 }}>
-        <IcoMoonIcon color={colors.theme950} name="Trash" size={24} />
-      </Pressable>
-    );
+    return <Button icon="Trash" style={{ height: 48 }} />;
   }, [handleDeleteFromHistory, colors]);
 
   return (
     <View style={[styles.container, { gap: isDesktop ? spacing.xl : spacing.md }]}>
       <Link href={videoHref} style={styles.thumbLinkWrapper}>
-        <VideoThumbnail
-          imageDimensions={{ width: isDesktop ? 328 : 128, height: isDesktop ? 102 : 72 }}
-          video={video}
-          backend={backend}
-          key={video.uuid}
-          timestamp={timestamp}
-        />
+        <Pressable
+          style={({ focused }) => ({
+            padding: focused ? 2 : 4,
+            borderWidth: focused ? 2 : 0,
+            borderColor: colors.theme950,
+            height: "100%",
+            width: "100%",
+            borderRadius: 10,
+          })}
+        >
+          <VideoThumbnail
+            imageDimensions={{ width: isDesktop ? 328 : 128, height: isDesktop ? 102 : 72 }}
+            video={video}
+            backend={backend}
+            key={video.uuid}
+            timestamp={timestamp}
+          />
+        </Pressable>
       </Link>
       <View style={styles.infoContainer}>
-        <View style={styles.textContainer}>
+        <TVFocusGuideView focusable={false} style={styles.textContainer}>
           {lastViewedAt && (
             <View style={{ flexDirection: "row", justifyContent: "space-between" }}>
               <Typography
@@ -77,7 +84,7 @@ export const VideoListItem = ({
             </View>
           )}
           <Link asChild href={videoHref}>
-            <Pressable onHoverOut={toggleHovered} onHoverIn={toggleHovered}>
+            <Pressable focusable={false} isTVSelectable={false} onHoverOut={toggleHovered} onHoverIn={toggleHovered}>
               <Typography
                 style={{ textDecorationLine: isHovered ? "underline" : undefined, maxWidth: "100%" }}
                 fontSize={isDesktop ? "sizeLg" : "sizeSm"}
@@ -96,7 +103,7 @@ export const VideoListItem = ({
           <Typography fontSize="sizeXS" fontWeight="Medium" color={colors.themeDesaturated500}>
             {`${video.publishedAt ? formatDistanceToNow(video.publishedAt, { addSuffix: true, locale: LANGUAGE_OPTIONS.find(({ value }) => value === i18n.language)?.dateLocale }) : ""} • ${t("views", { count: video.views })}`}
           </Typography>
-        </View>
+        </TVFocusGuideView>
         {isDesktop && deleteBtn}
       </View>
     </View>

--- a/OwnTube.tv/components/helpers/TVFocusGuideHelper/TVFocusGuideHelper.tsx
+++ b/OwnTube.tv/components/helpers/TVFocusGuideHelper/TVFocusGuideHelper.tsx
@@ -1,0 +1,3 @@
+import { TVFocusGuideView } from "react-native";
+
+export default TVFocusGuideView;

--- a/OwnTube.tv/components/helpers/TVFocusGuideHelper/TVFocusGuideHelper.web.tsx
+++ b/OwnTube.tv/components/helpers/TVFocusGuideHelper/TVFocusGuideHelper.web.tsx
@@ -1,0 +1,3 @@
+import { View } from "react-native";
+
+export default View;

--- a/OwnTube.tv/components/helpers/TVFocusGuideHelper/index.ts
+++ b/OwnTube.tv/components/helpers/TVFocusGuideHelper/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./TVFocusGuideHelper";

--- a/OwnTube.tv/components/shared/Button.tsx
+++ b/OwnTube.tv/components/shared/Button.tsx
@@ -52,12 +52,18 @@ export const Button = forwardRef<View, ButtonProps>(
           props.onHoverOut?.(e);
           toggleHovered();
         }}
-        style={({ pressed }) => [
+        style={({ pressed, focused }) => [
           styles.container,
           props.style,
           {
             backgroundColor: getBackgroundColor(pressed),
             justifyContent,
+            borderWidth: focused ? 2 : 0,
+            borderColor: colors.theme950,
+            paddingHorizontal:
+              (Number(props.style?.paddingHorizontal) || styles.container.paddingHorizontal || 0) - (focused ? 2 : 0),
+            paddingVertical:
+              (Number(props.style?.paddingVertical) || styles.container.paddingVertical || 0) - (focused ? 2 : 0),
           },
         ]}
         ref={ref}

--- a/OwnTube.tv/screens/HomeScreen/index.tsx
+++ b/OwnTube.tv/screens/HomeScreen/index.tsx
@@ -5,7 +5,7 @@ import { useMemo } from "react";
 import { useBreakpoints, useInstanceConfig, useViewHistory } from "../../hooks";
 import { spacing } from "../../theme";
 import { ROUTES } from "../../types";
-import { SectionList, StyleSheet, View } from "react-native";
+import { Platform, SectionList, StyleSheet, View } from "react-native";
 import { useTranslation } from "react-i18next";
 import { LatestVideosView, SectionHeader } from "./components";
 import { useLocalSearchParams } from "expo-router";
@@ -97,7 +97,11 @@ export const HomeScreen = () => {
           showsVerticalScrollIndicator={false}
           ListFooterComponent={<InfoFooter />}
           ListHeaderComponent={!isMobile ? <Spacer height={spacing.xl} /> : <></>}
-          style={{ paddingRight: isMobile ? 0 : spacing.xl, ...styles.paddingContainer }}
+          style={{
+            paddingRight: isMobile ? 0 : spacing.xl,
+            ...styles.paddingContainer,
+            flex: Platform.isTV ? 0 : 1,
+          }}
           renderSectionHeader={({ section: { title, link } }) => <SectionHeader title={title} link={link} />}
         />
       </View>


### PR DESCRIPTION
## 🚀 Description

This PR adds focus highlighting for Apple & Android TV app versions on app start page, sidebar, video lists and grids. See attached video for example. Artifacts available at https://github.com/mykhailodanilenko/web-client/actions/runs/11795474338

## 📄 Motivation and Context

#211 

## 🧪 How Has This Been Tested?

- [x] Web (desktop)
- [x] Web (mobile)
- [x] Mobile (iOS)
- [x] Mobile (Android)
- [x] TV (Android)
- [x] TV (tvOS)

## 📷 Screenshots (if appropriate)


https://github.com/user-attachments/assets/7dad8ab4-a5cb-47d5-bef1-2698ef80c7f4


## 📦 Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist (copied from README)

- [x] Squash your changes into a single clear and thoroughly descriptive commit, split changes into multiple commits only when it contributes to readability
- [x] Reference the GitHub issue that you are contributing on in your commit title or body
- [x] Sign your commits, as this is required by the automated GitHub PR checks
- [x] Ensure that the changes adhere to the project code style and formatting rules by running `npx eslint .` and `npx prettier --check ../` from the `./OwnTube.tv/` directory (without errors/warnings)
- [x] Include links and illustrations in your pull request to make it easy to review
- [x] Request a review by @mykhailodanilenko, @ar9708 and @mblomdahl
