### PR TITLE
Add support for modals and inputs on TV

### DIFF
--- a/OwnTube.tv/components/ComboBoxInput/ComboBoxInput.tsx
+++ b/OwnTube.tv/components/ComboBoxInput/ComboBoxInput.tsx
@@ -1,10 +1,11 @@
-import { Pressable, TextInput } from "react-native";
+import { Platform, Pressable, TextInput } from "react-native";
 import { useMemo } from "react";
 import { useTheme } from "@react-navigation/native";
 import { ComboBoxInputProps } from "./models";
 import { styles } from "./styles";
 import { useFullScreenModalContext } from "../../contexts";
 import { FullScreenSearchBox } from "./components";
+import { spacing } from "../../theme";
 
 const ComboBoxInput = ({
   onChange,
@@ -34,7 +35,10 @@ const ComboBoxInput = ({
   return (
     <Pressable
       testID={testID}
-      style={[styles.container, { backgroundColor: colors.theme100, borderColor: colors.theme200, width }]}
+      style={({ focused }) => [
+        styles.container,
+        { backgroundColor: colors.theme100, borderColor: focused ? colors.theme950 : colors.theme200, width },
+      ]}
       onPress={() => {
         modalControls.toggleModal(true);
         modalControls.setContent(modalContent);
@@ -49,8 +53,13 @@ const ComboBoxInput = ({
         placeholder={placeholder}
         placeholderTextColor={colors.text}
         style={[
-          { color: colors.theme950, backgroundColor: colors.theme100, borderColor: colors.theme200 },
           styles.input,
+          {
+            color: colors.theme950,
+            backgroundColor: colors.theme100,
+            borderColor: colors.theme200,
+            paddingLeft: Platform.isTV && Platform.OS === "ios" ? 0 : Platform.OS === "web" ? spacing.lg : spacing.lg,
+          },
         ]}
       />
     </Pressable>

--- a/OwnTube.tv/components/ComboBoxInput/components/DropdownItem.tsx
+++ b/OwnTube.tv/components/ComboBoxInput/components/DropdownItem.tsx
@@ -22,9 +22,9 @@ export const DropdownItem = ({
     <Pressable
       onHoverIn={() => setIsHovered(true)}
       onHoverOut={() => setIsHovered(false)}
-      style={[
+      style={({ focused }) => [
         {
-          backgroundColor: colors[isHovered ? "theme200" : "theme100"],
+          backgroundColor: colors[isHovered || focused ? "theme200" : "theme100"],
         },
         styles.container,
       ]}

--- a/OwnTube.tv/components/ComboBoxInput/components/FullScreenSearchBox.tsx
+++ b/OwnTube.tv/components/ComboBoxInput/components/FullScreenSearchBox.tsx
@@ -1,12 +1,14 @@
-import { FC, useCallback, useRef } from "react";
+import { FC, useCallback, useRef, useState } from "react";
 import { Button } from "../../shared";
-import { FlatList, StyleSheet, TextInput, View } from "react-native";
+import { FlatList, Platform, StyleSheet, TextInput, TVFocusGuideView, View } from "react-native";
 import { styles } from "../styles";
 import { DropdownItem, LIST_ITEM_HEIGHT } from "./DropdownItem";
-import { borderRadius } from "../../../theme";
+import { borderRadius, spacing } from "../../../theme";
 import { DropDownItem } from "../models";
 import { useFilteredDropdown } from "../hooks";
 import { useTheme } from "@react-navigation/native";
+import { TvKeyboard } from "../../TvKeyboard";
+import { Spacer } from "../../shared/Spacer";
 
 interface FullScreenSearchBoxProps {
   handleClose: () => void;
@@ -27,6 +29,8 @@ export const FullScreenSearchBox: FC<FullScreenSearchBoxProps> = ({
 }) => {
   const { colors } = useTheme();
   const listRef = useRef<FlatList | null>(null);
+  const [closeButtonRef, setCloseButtonRef] = useState<View | null>(null);
+  const [inputRef, setInputRef] = useState<TextInput | null>(null);
 
   const { inputValue, setInputValue, filteredList } = useFilteredDropdown(
     { data, onChange, allowCustomOptions, getCustomOptionText },
@@ -48,25 +52,64 @@ export const FullScreenSearchBox: FC<FullScreenSearchBoxProps> = ({
   );
 
   return (
-    <View style={{ flex: 1 }}>
-      <Button onPress={handleClose} icon="Close" style={componentStyles.closeBtn} />
-      <TextInput
-        autoFocus
-        placeholder={placeholder}
-        placeholderTextColor={colors.text}
-        style={[
-          styles.input,
-          { color: colors.theme950, backgroundColor: colors.theme100, borderColor: colors.theme200, height: 48 },
-        ]}
-        value={inputValue}
-        onChangeText={setInputValue}
-        onSubmitEditing={(event) => {
-          if (allowCustomOptions && event.nativeEvent.text) {
-            onChange(event.nativeEvent.text);
-            handleClose();
-          }
-        }}
-      />
+    <TVFocusGuideView trapFocusUp trapFocusLeft trapFocusRight trapFocusDown style={{ flex: 1, marginTop: 0 }}>
+      <View style={componentStyles.inputHeaderContainer}>
+        <TextInput
+          editable={!Platform.isTV}
+          autoFocus={!Platform.isTV}
+          placeholder={placeholder}
+          placeholderTextColor={colors.text}
+          style={[
+            styles.input,
+            {
+              color: colors.theme950,
+              backgroundColor: colors.theme100,
+              borderColor: colors.theme200,
+              height: 48,
+              paddingLeft: Platform.isTV && Platform.OS === "ios" ? 0 : spacing.lg,
+              flex: 1,
+            },
+          ]}
+          value={inputValue}
+          onChangeText={setInputValue}
+          onSubmitEditing={(event) => {
+            if (allowCustomOptions && event.nativeEvent.text) {
+              onChange(event.nativeEvent.text);
+              handleClose();
+            }
+          }}
+          ref={(node) => setInputRef(node)}
+        />
+        <Button
+          hasTVPreferredFocus
+          ref={(node) => setCloseButtonRef(node)}
+          onPress={handleClose}
+          icon="Close"
+          style={componentStyles.closeBtn}
+          // @ts-expect-error ref typings broken in react-native-tvos
+          nextFocusLeft={inputRef?.current}
+        />
+      </View>
+      {Platform.isTV ? (
+        <View style={componentStyles.tvKeyboardWrapper}>
+          <TvKeyboard
+            onBackspace={() =>
+              setInputValue((prev) => {
+                if (prev.length > 0) {
+                  return prev.slice(0, -1);
+                }
+
+                return prev;
+              })
+            }
+            onKeyPress={(key: string) => setInputValue((prev) => prev + key)}
+            // @ts-expect-error ref typings broken in react-native-tvos
+            nextFocusUp={closeButtonRef}
+          />
+        </View>
+      ) : (
+        <Spacer height={spacing.xs} />
+      )}
       <View
         style={[
           styles.optionsContainer,
@@ -91,20 +134,35 @@ export const FullScreenSearchBox: FC<FullScreenSearchBoxProps> = ({
             index,
           })}
           maxToRenderPerBatch={50}
-          style={componentStyles.list}
+          style={{ ...componentStyles.list, flex: Platform.isTV ? 0 : 1 }}
         />
       </View>
-    </View>
+    </TVFocusGuideView>
   );
 };
 
 const componentStyles = StyleSheet.create({
-  closeBtn: { height: 48, position: "absolute", right: 0, top: 0, zIndex: 2 },
+  closeBtn: { height: 48 },
+  inputHeaderContainer: {
+    alignItems: "center",
+    flexDirection: "row",
+    gap: 4,
+    minWidth: "100%",
+  },
   list: {
     borderRadius: borderRadius.radiusMd,
     flex: 1,
     position: "relative",
     zIndex: 1,
   },
-  optionsContainer: { height: "100%", maxHeight: null, width: "100%" },
+  optionsContainer: {
+    borderRadius: borderRadius.radiusMd,
+    height: "100%",
+    maxHeight: null,
+    overflow: "hidden",
+    position: "relative",
+    top: 0,
+    width: "100%",
+  },
+  tvKeyboardWrapper: { alignItems: "center", marginVertical: spacing.sm },
 });

--- a/OwnTube.tv/components/ComboBoxInput/styles.ts
+++ b/OwnTube.tv/components/ComboBoxInput/styles.ts
@@ -1,5 +1,5 @@
 import { StyleSheet } from "react-native";
-import { borderRadius, fontSizes, spacing } from "../../theme";
+import { borderRadius, fontSizes } from "../../theme";
 
 export const styles = StyleSheet.create({
   container: {
@@ -16,7 +16,7 @@ export const styles = StyleSheet.create({
     fontSize: fontSizes.sizeSm,
     fontWeight: "500",
     height: "100%",
-    paddingLeft: spacing.lg,
+    paddingLeft: 16,
     width: "100%",
   },
   optionsContainer: {

--- a/OwnTube.tv/components/InfoToast.tsx
+++ b/OwnTube.tv/components/InfoToast.tsx
@@ -25,7 +25,7 @@ export const InfoToast = ({ props: { isError }, ...toastProps }: InfoToastProps)
       <Typography numberOfLines={2} style={styles.text}>
         {toastProps.text1}
       </Typography>
-      <Button contrast="high" icon="Close" onPress={() => Toast.hide()} />
+      <Button hasTVPreferredFocus contrast="high" icon="Close" onPress={() => Toast.hide()} />
     </View>
   );
 };

--- a/OwnTube.tv/components/ModalContainer.tsx
+++ b/OwnTube.tv/components/ModalContainer.tsx
@@ -5,6 +5,7 @@ import { useTheme } from "@react-navigation/native";
 import { Typography } from "./Typography";
 import { Button } from "./shared";
 import { colors } from "../colors";
+import TVFocusGuideHelper from "./helpers/TVFocusGuideHelper";
 
 interface ModalContainerProps {
   title: string;
@@ -21,15 +22,21 @@ export const ModalContainer: FC<PropsWithChildren<ModalContainerProps>> = ({
   const { colors } = useTheme();
 
   return (
-    <View style={[styles.container, { backgroundColor: colors.theme50 }, containerStyle]}>
+    <TVFocusGuideHelper
+      trapFocusDown
+      trapFocusUp
+      trapFocusLeft
+      trapFocusRight
+      style={[styles.container, { backgroundColor: colors.theme50 }, containerStyle]}
+    >
       <View style={styles.header}>
         <Typography fontSize="sizeLg" fontWeight="SemiBold" color={colors.theme950} style={styles.headerText}>
           {title}
         </Typography>
-        <Button style={styles.button} onPress={onClose} icon="Close" />
+        <Button hasTVPreferredFocus style={styles.button} onPress={onClose} icon="Close" />
       </View>
       {children}
-    </View>
+    </TVFocusGuideHelper>
   );
 };
 

--- a/OwnTube.tv/components/TvKeyboard.tsx
+++ b/OwnTube.tv/components/TvKeyboard.tsx
@@ -1,0 +1,139 @@
+import { TouchableOpacity, TouchableOpacityProps } from "react-native";
+import { Typography } from "./Typography";
+import { borderRadius, spacing } from "../theme";
+import { useTheme } from "@react-navigation/native";
+import { forwardRef, PropsWithChildren, useRef, useState } from "react";
+import { Ionicons } from "@expo/vector-icons";
+import TVFocusGuideHelper from "./helpers/TVFocusGuideHelper";
+
+const urlSymbolsSet = {
+  chars: [
+    "a",
+    "b",
+    "c",
+    "d",
+    "e",
+    "f",
+    "g",
+    "h",
+    "i",
+    "j",
+    "k",
+    "l",
+    "m",
+    "n",
+    "o",
+    "p",
+    "q",
+    "r",
+    "s",
+    "t",
+    "u",
+    "v",
+    "w",
+    "x",
+    "y",
+    "z",
+  ],
+  symbols: ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "-", "_", "~", "/"],
+};
+
+const symbolSets = {
+  url: urlSymbolsSet,
+};
+
+const Key = forwardRef<
+  TouchableOpacity,
+  PropsWithChildren<
+    {
+      onKeyPress: () => void;
+    } & TouchableOpacityProps
+  >
+>(({ onKeyPress, children, nextFocusRight, nextFocusLeft, nextFocusUp }, ref) => {
+  const { colors } = useTheme();
+  const [focused, setFocused] = useState(false);
+
+  return (
+    <TouchableOpacity
+      activeOpacity={1}
+      ref={ref}
+      style={{
+        alignItems: "center",
+        justifyContent: "center",
+        borderRadius: borderRadius.radiusSm,
+        paddingHorizontal: spacing.xs - (focused ? 2 : 0),
+        paddingVertical: focused ? -2 : 0,
+        minWidth: spacing.xl,
+        backgroundColor: colors.theme200,
+        position: "relative",
+        zIndex: focused ? 1 : 0,
+        borderWidth: focused ? 2 : 0,
+        borderColor: colors.theme950,
+      }}
+      onFocus={() => setFocused(true)}
+      onBlur={() => setFocused(false)}
+      onPress={onKeyPress}
+      nextFocusRight={nextFocusRight}
+      nextFocusLeft={nextFocusLeft}
+      nextFocusUp={nextFocusUp}
+    >
+      {children}
+    </TouchableOpacity>
+  );
+});
+Key.displayName = "Key";
+
+interface TvKeyboardProps {
+  mode?: "url";
+  onKeyPress: (key: string) => void;
+  onBackspace: () => void;
+  nextFocusUp: number | undefined;
+}
+
+export const TvKeyboard = ({ mode = "url", onKeyPress, onBackspace, nextFocusUp }: TvKeyboardProps) => {
+  const { colors } = useTheme();
+
+  const [keyboardMode, setKeyboardMode] = useState<"chars" | "symbols">("chars");
+  const symbolsKeyRef = useRef();
+  const backspaceKeyRef = useRef();
+
+  return (
+    <TVFocusGuideHelper
+      autoFocus
+      trapFocusRight
+      trapFocusLeft
+      style={{ flexDirection: "row", gap: spacing.xs, height: spacing.xl, width: "100%", justifyContent: "center" }}
+    >
+      <Key
+        onKeyPress={() =>
+          setKeyboardMode((prev) => {
+            return prev === "chars" ? "symbols" : "chars";
+          })
+        }
+        // @ts-expect-error ref typings broken in react-native-tvos
+        ref={symbolsKeyRef}
+        nextFocusLeft={backspaceKeyRef?.current}
+        nextFocusUp={nextFocusUp}
+      >
+        <Typography color={colors.theme950}>{"123-/~"}</Typography>
+      </Key>
+      {symbolSets[mode][keyboardMode].map((char, idx) => (
+        <Key onKeyPress={() => onKeyPress(char)} key={idx} nextFocusUp={nextFocusUp}>
+          <Typography color={colors.theme950}>{char}</Typography>
+        </Key>
+      ))}
+      <Key onKeyPress={() => onKeyPress(".")} nextFocusUp={nextFocusUp}>
+        <Typography color={colors.theme950}>{"."}</Typography>
+      </Key>
+      <Key
+        nextFocusUp={nextFocusUp}
+        nextFocusRight={symbolsKeyRef?.current}
+        // @ts-expect-error ref typings broken in react-native-tvos
+        ref={backspaceKeyRef}
+        onKeyPress={onBackspace}
+      >
+        <Ionicons name="backspace" size={spacing.lg} color={colors.theme950} />
+      </Key>
+    </TVFocusGuideHelper>
+  );
+};

--- a/OwnTube.tv/components/VideoControlsOverlay/components/modals/Settings.tsx
+++ b/OwnTube.tv/components/VideoControlsOverlay/components/modals/Settings.tsx
@@ -1,6 +1,6 @@
 import Animated, { SlideInUp, SlideOutUp } from "react-native-reanimated";
 import { ModalContainer } from "../../../ModalContainer";
-import { ScrollView, StyleSheet, View } from "react-native";
+import { Platform, ScrollView, StyleSheet, View } from "react-native";
 import { Spacer } from "../../../shared/Spacer";
 import { spacing } from "../../../../theme";
 import { Button, Checkbox, Picker, Separator } from "../../../shared";
@@ -44,6 +44,14 @@ export const Settings = ({ onClose }: SettingsProps) => {
     });
   };
 
+  const handleSelectLanguage = (langCode: string) => {
+    handleChangeLang(langCode).then(() => {
+      if (Platform.isTV && Platform.OS === "android") {
+        onClose();
+      }
+    });
+  };
+
   return (
     <Animated.View entering={SlideInUp} exiting={SlideOutUp} style={styles.animatedContainer} pointerEvents="box-none">
       <ModalContainer onClose={onClose} title={t("settingsPageTitle")} containerStyle={styles.modalContainer}>
@@ -57,7 +65,7 @@ export const Settings = ({ onClose }: SettingsProps) => {
             darkTheme={isDarkTheme}
             placeholder={{}}
             value={currentLang}
-            onValueChange={handleChangeLang}
+            onValueChange={handleSelectLanguage}
             items={LANGUAGE_OPTIONS}
           />
           <Spacer height={spacing.xl} />

--- a/OwnTube.tv/components/index.ts
+++ b/OwnTube.tv/components/index.ts
@@ -30,3 +30,4 @@ export * from "./ErrorPage";
 export * from "./ErrorTextWithRetry";
 export * from "./InstanceLogo";
 export * from "./InfoToast";
+export * from "./TvKeyboard";

--- a/OwnTube.tv/components/shared/Checkbox.tsx
+++ b/OwnTube.tv/components/shared/Checkbox.tsx
@@ -29,7 +29,16 @@ export const Checkbox = ({ checked, onChange, disabled, label }: CheckboxProps) 
   }, [disabled, checked]);
 
   return (
-    <Pressable onPress={handleCheck} style={{ flexDirection: "row", alignItems: "center", gap: spacing.md }}>
+    <Pressable
+      onPress={handleCheck}
+      style={({ focused }) => ({
+        padding: focused ? 0 : -2,
+        margin: focused ? 0 : 2,
+        borderWidth: focused ? 2 : 0,
+        borderColor: colors.theme950,
+        ...styles.focusableContainer,
+      })}
+    >
       <View
         style={[
           styles.checkboxContainer,
@@ -60,5 +69,12 @@ const styles = StyleSheet.create({
     height: 20,
     justifyContent: "center",
     width: 20,
+  },
+  focusableContainer: {
+    alignItems: "center",
+    alignSelf: "flex-start",
+    borderRadius: borderRadius.radiusSm,
+    flexDirection: "row",
+    gap: spacing.md,
   },
 });


### PR DESCRIPTION
## 🚀 Description

This PR makes modals accessible for TV devices and adds text and select input for TV.

## 📄 Motivation and Context

closes #215, closes #213 

## 🧪 How Has This Been Tested?

- [x] Web (desktop)
- [x] Web (mobile)
- [x] Mobile (iOS)
- [x] Mobile (Android)
- [x] TV (Android)
- [x] TV (Apple)

## 📷 Screenshots (if appropriate)

Android TV search combobox with onscreen keyboard:

https://github.com/user-attachments/assets/fc97e62b-678c-4c36-8745-8f893a2abbe0

Same on Apple TV:

https://github.com/user-attachments/assets/d1bf51cb-9967-4024-824e-e62a052b8865

## 📦 Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist (copied from README)

- [x] Squash your changes into a single clear and thoroughly descriptive commit, split changes into multiple commits only when it contributes to readability
- [x] Reference the GitHub issue that you are contributing on in your commit title or body
- [x] Sign your commits, as this is required by the automated GitHub PR checks
- [x] Ensure that the changes adhere to the project code style and formatting rules by running `npx eslint .` and `npx prettier --check ../` from the `./OwnTube.tv/` directory (without errors/warnings)
- [x] Include links and illustrations in your pull request to make it easy to review
- [x] Request a review by @mykhailodanilenko, @ar9708 and @mblomdahl
