### PR TITLE
Enable running builds from customized branded repos

### DIFF
--- a/.github/workflows/build_android_apk.yml
+++ b/.github/workflows/build_android_apk.yml
@@ -6,11 +6,11 @@ on:
       owntube_source:
         required: false
         type: string
-        description: "The repository with OwnTube code. Defaults to the source repository."
+        description: "The repository with OwnTube-tv/web-client code. Defaults to the source repository."
       use_parent_repo_customizations:
         required: false
         type: boolean
-        description: "Should the root repo be used for customizations? (needed for branded builds)"
+        description: "Should a parent repo be used for customizations? (Required for branded builds)"
       customizations_env_content:
         required: false
         type: string

--- a/.github/workflows/build_android_tv_apk.yml
+++ b/.github/workflows/build_android_tv_apk.yml
@@ -6,11 +6,11 @@ on:
       owntube_source:
         required: false
         type: string
-        description: "The repository with OwnTube code. Defaults to the source repository."
+        description: "The repository with OwnTube-tv/web-client code. Defaults to the source repository."
       use_parent_repo_customizations:
         required: false
         type: boolean
-        description: "Should the root repo be used for customizations? (needed for branded builds)"
+        description: "Should a parent repo be used for customizations? (Required for branded builds)"
       customizations_env_content:
         required: false
         type: string

--- a/.github/workflows/build_ios_simulator_app.yml
+++ b/.github/workflows/build_ios_simulator_app.yml
@@ -6,11 +6,11 @@ on:
       owntube_source:
         required: false
         type: string
-        description: "The repository with OwnTube code. Defaults to the source repository."
+        description: "The repository with OwnTube-tv/web-client code. Defaults to the source repository."
       use_parent_repo_customizations:
         required: false
         type: boolean
-        description: "Should the root repo be used for customizations? (needed for branded builds)"
+        description: "Should a parent repo be used for customizations? (Required for branded builds)"
       runner-label:
         type: string
         default: "macos-latest"

--- a/.github/workflows/build_tvos_simulator_app.yml
+++ b/.github/workflows/build_tvos_simulator_app.yml
@@ -6,11 +6,11 @@ on:
       owntube_source:
         required: false
         type: string
-        description: "The repository with OwnTube code. Defaults to the source repository."
+        description: "The repository with OwnTube-tv/web-client code. Defaults to the source repository."
       use_parent_repo_customizations:
         required: false
         type: boolean
-        description: "Should the root repo be used for customizations? (needed for branded builds)"
+        description: "Should a parent repo be used for customizations? (Required for branded builds)"
       runner-label:
         type: string
         default: "macos-latest"

--- a/.github/workflows/deploy_web.yml
+++ b/.github/workflows/deploy_web.yml
@@ -12,11 +12,11 @@ on:
       owntube_source:
         required: false
         type: string
-        description: "The repository with OwnTube code. Defaults to the source repository."
+        description: "The repository with OwnTube-tv/web-client code. Defaults to the source repository."
       use_parent_repo_customizations:
         required: false
         type: boolean
-        description: "Should the root repo be used for customizations? (needed for branded builds)"
+        description: "Should a parent repo be used for customizations? (Required for branded builds)"
 
 jobs:
   deploy_web:

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -6,11 +6,11 @@ on:
       owntube_source:
         required: false
         type: string
-        description: "The repository with OwnTube code. Defaults to the source repository."
+        description: "The repository with OwnTube-tv/web-client code. Defaults to the source repository."
       use_parent_repo_customizations:
         required: false
         type: boolean
-        description: "Should the root repo be used for customizations? (needed for branded builds)"
+        description: "Should a parent repo be used for customizations? (Required for branded builds)"
       target:
         required: true
         type: string


### PR DESCRIPTION
## 🚀 Description

This PR creates the conditions for running builds from customized branded app repos generated with the [template repo](https://github.com/OwnTube-tv/owntube-branded-app-template/tree/main). Once it is merged it will be possible to generate repos like [this](https://github.com/OwnTube-tv/cust-app-blender) and run builds in them.

## 📄 Motivation and Context

#253

## 🧪 How Has This Been Tested?

- [x] Web (desktop)
- [x] Web (mobile)
- [x] Mobile (iOS)
- [x] Mobile (Android)
- [x] TV (Android)
- [x] TV (Apple)

## 📦 Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist (copied from README)

- [x] Squash your changes into a single clear and thoroughly descriptive commit, split changes into multiple commits only when it contributes to readability
- [x] Reference the GitHub issue that you are contributing on in your commit title or body
- [x] Sign your commits, as this is required by the automated GitHub PR checks
- [x] Ensure that the changes adhere to the project code style and formatting rules by running `npx eslint .` and `npx prettier --check ../` from the `./OwnTube.tv/` directory (without errors/warnings)
- [x] Include links and illustrations in your pull request to make it easy to review
- [x] Request a review by @mykhailodanilenko, @ar9708 and @mblomdahl
