### PR TITLE
Fix android icons falling back to owntube

### DIFF
--- a/OwnTube.tv/app.config.ts
+++ b/OwnTube.tv/app.config.ts
@@ -6,11 +6,13 @@ const getBuildNumber = ({ platform }: { platform: "ios" | "android" }) => {
   return isAndroid ? buildNumber.slice(0, -1) : buildNumber;
 };
 
+const icon =
+  process.env.EXPO_PUBLIC_ICON || (process.env.EXPO_TV ? "./assets/appleTV/icon_1280x768.png" : "./assets/icon.png");
+
 export default {
   slug: process.env.EXPO_PUBLIC_APP_SLUG || "OwnTube.tv",
   name: process.env.EXPO_PUBLIC_APP_NAME || "OwnTube.tv",
-  icon:
-    process.env.EXPO_PUBLIC_ICON || (process.env.EXPO_TV ? "./assets/appleTV/icon_1280x768.png" : "./assets/icon.png"),
+  icon,
   scheme: "owntube",
   version: process.env.EXPO_PUBLIC_APP_VERSION || "1.0.0",
   assetBundlePatterns: ["**/*"],
@@ -41,11 +43,9 @@ export default {
     blockedPermissions: ["RECORD_AUDIO"],
     versionCode: getBuildNumber({ platform: "android" }),
     adaptiveIcon: {
-      foregroundImage:
-        process.env.EXPO_PUBLIC_ANDROID_ADAPTIVE_ICON_FOREGROUND || "./assets/adaptive-icon-foreground.png",
-      monochromeImage:
-        process.env.EXPO_PUBLIC_ANDROID_ADAPTIVE_ICON_MONOCHROME || "./assets/adaptive-icon-foreground.png",
-      backgroundColor: process.env.EXPO_PUBLIC_ANDROID_ADAPTIVE_ICON_BG_COLOR || "#F95F1E",
+      foregroundImage: process.env.EXPO_PUBLIC_ANDROID_ADAPTIVE_ICON_FOREGROUND,
+      monochromeImage: process.env.EXPO_PUBLIC_ANDROID_ADAPTIVE_ICON_MONOCHROME,
+      backgroundColor: process.env.EXPO_PUBLIC_ANDROID_ADAPTIVE_ICON_BG_COLOR,
     },
     package: process.env.EXPO_PUBLIC_ANDROID_PACKAGE || "com.owntubetv.owntube",
     intentFilters: process.env.EXPO_PUBLIC_CUSTOM_DEPLOYMENT_URL


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description
This PR fixes android icons that were overwritten by the multilayer OwnTube icon. MishaTube Android app has the updated icon as an example.
<!-- Describe your changes in detail -->

## 📄 Motivation and Context
closes #295
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## 🧪 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

- [ ] Web (desktop)
- [ ] Web (mobile)
- [ ] Mobile (iOS)
- [x] Mobile (Android)
- [ ] TV (Android)
- [ ] TV (Apple)

## 📷 Screenshots (if appropriate)

<!-- Please provide a screenshot of your change -->

## 📦 Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist (copied from README)

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Squash your changes into a single clear and thoroughly descriptive commit, split changes into multiple commits only when it contributes to readability
- [x] Reference the GitHub issue that you are contributing on in your commit title or body
- [x] Sign your commits, as this is required by the automated GitHub PR checks
- [x] Ensure that the changes adhere to the project code style and formatting rules by running `npx eslint .` and `npx prettier --check ../` from the `./OwnTube.tv/` directory (without errors/warnings)
- [x] Include links and illustrations in your pull request to make it easy to review
- [x] Request a review by @mykhailodanilenko, @ar9708 and @mblomdahl
