### PR TITLE
Add customization for footer icon, fix android build failing by downgrading expo-device

### DIFF
--- a/OwnTube.tv/.env.example
+++ b/OwnTube.tv/.env.example
@@ -21,3 +21,4 @@ EXPO_PUBLIC_ICON_512=https://cdn-icons-png.flaticon.com/512/1170/1170688.png
 EXPO_APP_THEME_COLOR='#000000'
 EXPO_APP_BG_COLOR='#FFFFFF'
 EXPO_APP_DESCRIPTION=A nice PeerTube client app.
+EXPO_PUBLIC_FOOTER_LOGO=https://cdn-icons-png.flaticon.com/512/1170/1170688.png

--- a/OwnTube.tv/components/InfoFooter.tsx
+++ b/OwnTube.tv/components/InfoFooter.tsx
@@ -5,6 +5,7 @@ import { useTheme } from "@react-navigation/native";
 import { BuildInfo } from "./BuildInfo";
 import { Typography } from "./Typography";
 import { useTranslation } from "react-i18next";
+import { Image } from "react-native";
 
 interface InfoFooterProps {
   showBuildInfo?: boolean;
@@ -16,7 +17,11 @@ export const InfoFooter = ({ showBuildInfo }: InfoFooterProps) => {
 
   return (
     <View style={styles.container}>
-      <Logo textColor={colors.theme950} width={73} height={32} />
+      {process.env.EXPO_PUBLIC_FOOTER_LOGO ? (
+        <Image source={{ uri: process.env.EXPO_PUBLIC_FOOTER_LOGO }} style={{ width: 73, height: 73 }} />
+      ) : (
+        <Logo textColor={colors.theme950} width={73} height={32} />
+      )}
       {showBuildInfo && (
         <View style={styles.buildInfoContainer}>
           {process.env.EXPO_PUBLIC_HIDE_GIT_DETAILS ? (

--- a/OwnTube.tv/package-lock.json
+++ b/OwnTube.tv/package-lock.json
@@ -29,7 +29,7 @@
         "expo-asset": "~11.0.1",
         "expo-clipboard": "~7.0.1",
         "expo-constants": "~17.0.3",
-        "expo-device": "~7.1.4",
+        "expo-device": "7.0.3",
         "expo-file-system": "~18.0.6",
         "expo-font": "~13.0.2",
         "expo-linear-gradient": "~14.0.2",
@@ -11280,9 +11280,9 @@
       }
     },
     "node_modules/expo-device": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/expo-device/-/expo-device-7.1.4.tgz",
-      "integrity": "sha512-HS04IiE1Fy0FRjBLurr9e5A6yj3kbmQB+2jCZvbSGpsjBnCLdSk/LCii4f5VFhPIBWJLyYuN5QqJyEAw6BcS4Q==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/expo-device/-/expo-device-7.0.3.tgz",
+      "integrity": "sha512-uNGhDYmpDj/3GySWZmRiYSt52Phdim11p0pXfgpCq/nMks0+UPZwl3D0vin5N8/gpVe5yzb13GYuFxiVoDyniw==",
       "license": "MIT",
       "dependencies": {
         "ua-parser-js": "^0.7.33"

--- a/OwnTube.tv/package.json
+++ b/OwnTube.tv/package.json
@@ -33,7 +33,7 @@
     "expo-asset": "~11.0.1",
     "expo-clipboard": "~7.0.1",
     "expo-constants": "~17.0.3",
-    "expo-device": "~7.1.4",
+    "expo-device": "7.0.3",
     "expo-file-system": "~18.0.6",
     "expo-font": "~13.0.2",
     "expo-linear-gradient": "~14.0.2",

--- a/docs/customizations.md
+++ b/docs/customizations.md
@@ -54,6 +54,8 @@ or background images for Apple TV.
 
 `EXPO_PUBLIC_HIDE_GIT_DETAILS`: hide or show the build info section on git commit and author
 
+`EXPO_PUBLIC_FOOTER_LOGO`: custom footer logo instead of OwnTube.tv logo
+
 > [!WARNING]
 > You need to supply images of expected sizes for tvOS, or the build fails automatically:
 >


### PR DESCRIPTION

<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description
This PR adds customizations for footer image, while also fixing Android builds.
<!-- Describe your changes in detail -->

## 📄 Motivation and Context
closes #326 
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## 🧪 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

- [x] Web (desktop)
- [x] Web (mobile)
- [x] Mobile (iOS)
- [x] Mobile (Android)
- [x] TV (Android)
- [x] TV (Apple)

## 📷 Screenshots (if appropriate)
<img width="404" alt="image" src="https://github.com/user-attachments/assets/30e0823f-b139-456f-bf9d-0782bcf1e194" />

<!-- Please provide a screenshot of your change -->

## 📦 Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist (copied from README)

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Squash your changes into a single clear and thoroughly descriptive commit, split changes into multiple commits only when it contributes to readability
- [x] Reference the GitHub issue that you are contributing on in your commit title or body
- [x] Sign your commits, as this is required by the automated GitHub PR checks
- [x] Ensure that the changes adhere to the project code style and formatting rules by running `npx eslint .` and `npx prettier --check ../` from the `./OwnTube.tv/` directory (without errors/warnings)
- [x] Include links and illustrations in your pull request to make it easy to review
- [x] Request a review by @mykhailodanilenko, @ar9708 and @mblomdahl
