### PR TITLE
Add resolution hint for auto quality on web & android

### DIFF
--- a/OwnTube.tv/components/PlaybackSettingsPopup.tsx
+++ b/OwnTube.tv/components/PlaybackSettingsPopup.tsx
@@ -22,6 +22,7 @@ interface PlaybackSettingsPopupProps {
   handleSetCCLang?: (lang: string) => void;
   selectedCCLang?: string;
   isLiveVideo?: boolean;
+  hlsAutoQuality?: number;
 }
 
 const Setting = ({ name, state, onPress }: { name: string; state?: string; onPress: () => void }) => {
@@ -134,6 +135,7 @@ export const PlaybackSettingsPopup = ({
   handleSetCCLang,
   selectedCCLang,
   isLiveVideo,
+  hlsAutoQuality,
 }: PlaybackSettingsPopupProps) => {
   const { colors } = useTheme();
   const { t } = useTranslation();
@@ -147,7 +149,12 @@ export const PlaybackSettingsPopup = ({
       videoData?.streamingPlaylists?.[0]?.files?.length ? videoData?.streamingPlaylists?.[0]?.files : videoData?.files
     )
       ?.map(({ resolution }) => ({ ...resolution, id: String(resolution.id) }))
-      .concat([{ id: "auto", label: t("auto") }]);
+      .concat([
+        {
+          id: "auto",
+          label: `${t("auto")}${hlsAutoQuality && selectedQuality === "auto" ? " " + hlsAutoQuality + "p" : ""}`,
+        },
+      ]);
     const ccOptions = [{ id: "", label: t("off") }].concat(
       videoCaptions?.map(({ language }) => ({ id: language.id, label: language.label })) || [],
     );

--- a/OwnTube.tv/components/VideoControlsOverlay/VideoControlsOverlay.tsx
+++ b/OwnTube.tv/components/VideoControlsOverlay/VideoControlsOverlay.tsx
@@ -65,6 +65,7 @@ export interface VideoControlsOverlayProps {
   setSelectedCCLang?: (lang: string) => void;
   isLiveVideo?: boolean;
   isWaitingForLive: boolean;
+  hlsAutoQuality?: number;
 }
 
 const VideoControlsOverlay = ({
@@ -109,6 +110,7 @@ const VideoControlsOverlay = ({
   setSelectedCCLang,
   isLiveVideo,
   isWaitingForLive,
+  hlsAutoQuality,
 }: PropsWithChildren<VideoControlsOverlayProps>) => {
   const {
     isSeekBarFocused,
@@ -223,6 +225,7 @@ const VideoControlsOverlay = ({
                       selectedSpeed={speed}
                       handleSetCCLang={setSelectedCCLang}
                       selectedCCLang={selectedCCLang}
+                      hlsAutoQuality={hlsAutoQuality}
                     />
                   </View>
                 )}

--- a/OwnTube.tv/components/VideoView/VideoView.tsx
+++ b/OwnTube.tv/components/VideoView/VideoView.tsx
@@ -11,7 +11,11 @@ import { ROUTES } from "../../types";
 import { RootStackParams } from "../../app/_layout";
 import { TextTracks, TextTrackType, Video, VideoRef } from "react-native-video";
 import { SelectedTrackType } from "react-native-video/src/types/video";
-import type { OnProgressData, OnVideoErrorData } from "react-native-video/src/specs/VideoNativeComponent";
+import type {
+  OnBandwidthUpdateData,
+  OnProgressData,
+  OnVideoErrorData,
+} from "react-native-video/src/specs/VideoNativeComponent";
 import { OnLoadData, OnTextTracksData } from "react-native-video/src/types/events";
 import GoogleCast, {
   MediaHlsSegmentFormat,
@@ -328,6 +332,15 @@ const VideoView = ({
     }, [isCCAvailable, availableCCLangs, sessionCCLocale]),
   );
 
+  const [hlsResolution, setHlsResolution] = useState<number | undefined>();
+  const handleBandwidthUpdate = (event: OnBandwidthUpdateData) => {
+    if (Platform.OS !== "android") {
+      return;
+    }
+
+    setHlsResolution(event.height);
+  };
+
   return (
     <View collapsable={false} style={styles.container}>
       <VideoControlsOverlay
@@ -369,6 +382,7 @@ const VideoView = ({
         selectedCCLang={selectedCCLang}
         isCCVisible={isCCShown}
         isWaitingForLive={isWaitingForLive}
+        hlsAutoQuality={hlsResolution}
       >
         {googleCastClient ? (
           <IcoMoonIcon name="Chromecast" size={72} color={colors.white80} />
@@ -400,6 +414,8 @@ const VideoView = ({
           </View>
         ) : (
           <Video
+            reportBandwidth
+            onBandwidthUpdate={handleBandwidthUpdate}
             onEnd={() => setShouldReplay(true)}
             onLoad={handleVideoLoaded}
             onProgress={handleProgress}

--- a/OwnTube.tv/components/VideoView/styles.ts
+++ b/OwnTube.tv/components/VideoView/styles.ts
@@ -18,6 +18,8 @@ export const styles = StyleSheet.create({
     flex: 1,
     justifyContent: "center",
   },
+  liveStreamOfflineOverlay: { alignItems: "center", flex: 1, justifyContent: "center", zIndex: 1 },
+  liveStreamPoster: { bottom: 0, flex: 1, left: 0, position: "absolute", right: 0, top: 0 },
   opacityOverlay: {
     backgroundColor: colors.dark.black50,
     bottom: 0,


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description
This PR adds a hint to the "Auto" quality option on Web and Android platforms. Due to limitations faced by react-native-video on iOS, the resolution is not reported for HLS videos there, so this feature will only be available on the mentioned platforms for now. As usual, see updates at https://cust-app-mishatube.owntube.tv/
<!-- Describe your changes in detail -->

## 📄 Motivation and Context
#339
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## 🧪 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

- [x] Web (desktop)
- [x] Web (mobile)
- [x] Mobile (iOS)
- [x] Mobile (Android)
- [ ] TV (Android)
- [ ] TV (Apple)

## 📦 Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist (copied from README)

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Squash your changes into a single clear and thoroughly descriptive commit, split changes into multiple commits only when it contributes to readability
- [x] Reference the GitHub issue that you are contributing on in your commit title or body
- [x] Sign your commits, as this is required by the automated GitHub PR checks
- [x] Ensure that the changes adhere to the project code style and formatting rules by running `npx eslint .` and `npx prettier --check ../` from the `./OwnTube.tv/` directory (without errors/warnings)
- [x] Include links and illustrations in your pull request to make it easy to review
- [x] Request a review by @mykhailodanilenko, @ar9708 and @mblomdahl
