### PR TITLE
Remove strobing on orientation change for mobile platforms

### DIFF
--- a/OwnTube.tv/hooks/useBreakpoints.ts
+++ b/OwnTube.tv/hooks/useBreakpoints.ts
@@ -3,5 +3,5 @@ import { useWindowDimensions } from "react-native";
 export const useBreakpoints = () => {
   const { width } = useWindowDimensions();
 
-  return { isDesktop: width > 959, isMobile: width <= 600 };
+  return { isDesktop: width > 959, isMobile: width <= 600, isTablet: width <= 959 && width > 600 };
 };


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description
In this PR, the calculation logic for video list columns is changed to prevent erratic resizing on orientation change on mobile. The best solution I was able to find is to rely on React Native's built-in "list columns" functionality, with a fixed number of columns for each screen variant - 4 on TV, 3 on landscape tablets, 2 on portrait tablets and landscape phones and 1 on portrait phones. When orientation changes, the layout is recalculated 1 time instead of 10, albeit with a small delay - the other option was to add a delay anyway so this shouldn't be worse than hardcoding a 300ms delay.
<!-- Describe your changes in detail -->

## 📄 Motivation and Context
#366 
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## 🧪 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

- [x] Web (desktop)
- [x] Web (mobile)
- [x] Mobile (iOS)
- [x] Mobile (Android)
- [ ] TV (Android)
- [x] TV (Apple)

## 📦 Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist (copied from README)

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Squash your changes into a single clear and thoroughly descriptive commit, split changes into multiple commits only when it contributes to readability
- [x] Reference the GitHub issue that you are contributing on in your commit title or body
- [x] Sign your commits, as this is required by the automated GitHub PR checks
- [x] Ensure that the changes adhere to the project code style and formatting rules by running `npx eslint .` and `npx prettier --check ../` from the `./OwnTube.tv/` directory (without errors/warnings)
- [x] Include links and illustrations in your pull request to make it easy to review
- [x] Request a review by @mykhailodanilenko, @ar9708 and @mblomdahl
