### PR TITLE
Bug fixes and refactoring storage

### DIFF
--- a/OwnTube.tv/components/ViewHistory.tsx
+++ b/OwnTube.tv/components/ViewHistory.tsx
@@ -44,7 +44,12 @@ export const ViewHistory = () => {
         style={styles.clearModalWrapper}
         pointerEvents="box-none"
       >
-        <ModalContainer onClose={() => toggleModal(false)} title={t("clearSiteHistoryQuestion")}>
+        <ModalContainer
+          onClose={() => toggleModal(false)}
+          title={t("clearSiteHistoryQuestion", {
+            appName: currentInstanceConfig?.customizations?.pageTitle ?? backend,
+          })}
+        >
           <View style={styles.modalContentContainer}>
             <Button onPress={() => toggleModal(false)} text={t("cancel")} />
             <Button
@@ -106,7 +111,9 @@ export const ViewHistory = () => {
         <Button
           icon="Trash"
           onPress={handleClearConfirmation}
-          text={t("clearSiteHistory", { appName: currentInstanceConfig?.customizations?.pageTitle ?? backend })}
+          text={t("clearSiteHistory", {
+            appName: currentInstanceConfig?.customizations?.pageTitle ?? backend,
+          })}
         />
       </View>
       <Spacer height={spacing.xl} />

--- a/OwnTube.tv/contexts/AppConfigContext.tsx
+++ b/OwnTube.tv/contexts/AppConfigContext.tsx
@@ -86,7 +86,9 @@ export const AppConfigContextProvider = ({ children }: PropsWithChildren) => {
 
   useEffect(() => {
     queryClient.setDefaultOptions({
-      queries: { staleTime: currentInstanceConfig?.customizations?.refreshQueriesStaleTime || GLOBAL_QUERY_STALE_TIME },
+      queries: {
+        staleTime: currentInstanceConfig?.customizations?.refreshQueriesStaleTimeMs || GLOBAL_QUERY_STALE_TIME,
+      },
     });
   }, [currentInstanceConfig, queryClient]);
 

--- a/OwnTube.tv/hooks/useViewHistory.ts
+++ b/OwnTube.tv/hooks/useViewHistory.ts
@@ -30,9 +30,41 @@ export const useViewHistory = (queryArg?: { enabled?: boolean; maxItems?: number
     queryFn: async () => {
       const history: string[] | undefined = await readFromAsyncStorage(STORAGE.VIEW_HISTORY);
 
-      const entries = await multiGetFromAsyncStorage(history || []);
+      // Try the new format first, fall back to the old format for backward compatibility
+      const newFormatKeys = (history || []).map((uuid) => `view_history/${uuid}`);
 
-      return Object.fromEntries((entries || []).map(([key, value]) => [key, JSON.parse(value || "")]));
+      // TODO(clean-up): Remove in July 2025 when all clients are migrated
+      const oldFormatKeys = history || [];
+
+      const newEntries = await multiGetFromAsyncStorage(newFormatKeys);
+
+      // TODO(clean-up): Remove in July 2025 when all clients are migrated
+      const oldEntries = await multiGetFromAsyncStorage(oldFormatKeys);
+
+      const result: ViewHistoryBase = {};
+
+      // Process new format entries
+      newEntries?.forEach(([key, value]) => {
+        if (value) {
+          const uuid = key.replace("view_history/", "");
+          result[uuid] = JSON.parse(value);
+        }
+      });
+
+      // TODO(clean-up): Remove in July 2025 when all clients are migrated
+      // Process old format entries (fallback) and migrate them
+      for (const [uuid, value] of oldEntries || []) {
+        if (value && !result[uuid]) {
+          const entry = JSON.parse(value);
+          result[uuid] = entry;
+
+          // Lazy migration: move old entry to new format
+          await writeToAsyncStorage(`view_history/${uuid}`, entry);
+          await deleteFromAsyncStorage([uuid]);
+        }
+      }
+
+      return result;
     },
     staleTime: 0,
     select: (data) =>
@@ -50,12 +82,23 @@ export const useViewHistory = (queryArg?: { enabled?: boolean; maxItems?: number
       if (!history?.includes(data.uuid)) {
         const updatedHistory = [data.uuid, ...(history || [])];
         const staleEntries = updatedHistory.slice(maxItems);
-        deleteFromAsyncStorage(staleEntries);
+        await deleteFromAsyncStorage(staleEntries.map((uuid) => `view_history/${uuid}`));
 
         await writeToAsyncStorage(STORAGE.VIEW_HISTORY, updatedHistory.slice(0, maxItems));
       }
 
-      const videoToUpdate = await readFromAsyncStorage(data.uuid);
+      const videoKey = `view_history/${data.uuid}`;
+      let videoToUpdate = await readFromAsyncStorage(videoKey);
+
+      // TODO(clean-up): Remove in July 2025 when all clients are migrated
+      // Fallback: check the old format if not found in the new format
+      if (!videoToUpdate) {
+        videoToUpdate = await readFromAsyncStorage(data.uuid);
+        // If found in old format, clean it up after migration
+        if (videoToUpdate) {
+          await deleteFromAsyncStorage([data.uuid]);
+        }
+      }
 
       const updatedVideoEntry = {
         ...(videoToUpdate || {}),
@@ -64,7 +107,7 @@ export const useViewHistory = (queryArg?: { enabled?: boolean; maxItems?: number
         timestamp: data.timestamp ?? 0,
       };
 
-      await writeToAsyncStorage(data.uuid, updatedVideoEntry);
+      await writeToAsyncStorage(videoKey, updatedVideoEntry);
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: ["viewHistory"] });
@@ -75,7 +118,11 @@ export const useViewHistory = (queryArg?: { enabled?: boolean; maxItems?: number
     mutationFn: async () => {
       const history: string[] = await readFromAsyncStorage(STORAGE.VIEW_HISTORY);
 
-      await deleteFromAsyncStorage(history);
+      // Delete both new and old format entries
+      await deleteFromAsyncStorage(history.map((uuid) => `view_history/${uuid}`));
+
+      // TODO(clean-up): Remove in July 2025 when all clients are migrated
+      await deleteFromAsyncStorage(history); // old format cleanup
       await deleteFromAsyncStorage([STORAGE.VIEW_HISTORY]);
     },
     onSuccess: () => {
@@ -90,16 +137,26 @@ export const useViewHistory = (queryArg?: { enabled?: boolean; maxItems?: number
       const toKeep: string[] = [];
 
       for (const uuid of history) {
-        const entry: ViewHistoryEntry = await readFromAsyncStorage(uuid);
+        let entry: ViewHistoryEntry = await readFromAsyncStorage(`view_history/${uuid}`);
 
-        if (entry.backend === backend) {
+        // TODO(clean-up): Remove in July 2025 when all clients are migrated
+        // Fallback to the old format if it is not found in the new format
+        if (!entry) {
+          entry = await readFromAsyncStorage(uuid);
+        }
+
+        if (entry?.backend === backend) {
           toDelete.push(uuid);
         } else {
           toKeep.push(uuid);
         }
       }
 
-      await deleteFromAsyncStorage(toDelete);
+      // Delete both new and old format entries
+      await deleteFromAsyncStorage(toDelete.map((uuid) => `view_history/${uuid}`));
+
+      // TODO(clean-up): Remove in July 2025 when all clients are migrated
+      await deleteFromAsyncStorage(toDelete); // old format cleanup
       await writeToAsyncStorage(STORAGE.VIEW_HISTORY, toKeep);
     },
     onSuccess: () => {
@@ -120,7 +177,11 @@ export const useViewHistory = (queryArg?: { enabled?: boolean; maxItems?: number
       STORAGE.VIEW_HISTORY,
       history.filter((entry) => entry !== uuid),
     );
-    await deleteFromAsyncStorage([uuid]);
+    // Delete both new and old format entries
+    await deleteFromAsyncStorage([
+      `view_history/${uuid}`,
+      uuid, // TODO(clean-up): Remove in July 2025 when all clients are migrated
+    ]);
     await queryClient.invalidateQueries({ queryKey: ["viewHistory"] });
   };
 

--- a/OwnTube.tv/instanceConfigs.ts
+++ b/OwnTube.tv/instanceConfigs.ts
@@ -23,7 +23,7 @@ const customizationsSchema = z
     hideVideoSiteLinks: z.boolean(),
     hideChannelPlaylistLinks: z.boolean(),
     homeFeaturedLives: z.array(z.string()),
-    refreshQueriesStaleTime: z.number(),
+    refreshQueriesStaleTimeMs: z.number(),
   })
   .partial();
 

--- a/OwnTube.tv/public/featured-instances.json5
+++ b/OwnTube.tv/public/featured-instances.json5
@@ -5,7 +5,7 @@
     hostname: "tube.rebellion.global",
     logoUrl: "https://owntube-tv.github.io/web-client/logos/tube.rebellion.global.png",
     customizations: {
-      refreshQueriesStaleTime: 10000,
+      refreshQueriesStaleTimeMs: 10000,
       homeLatestPublishedVideoCount: 12,
       homeRecentlyWatchedVideoCount: 4,
       homeHideChannelsOverview: false,


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description

### Before

Error before:

<img width="1264" alt="Screenshot 2025-05-29 at 11 58 26" src="https://github.com/user-attachments/assets/daa3b614-1e9a-4aa9-ae3a-b9e2f7601600" />

Non-beautiful LocalStorage layout with only UUIDs as keys:

<img width="1069" alt="Screenshot 2025-05-29 at 12 02 25" src="https://github.com/user-attachments/assets/ebc45da9-5c5c-45db-a778-dcf25a5642aa" />


### After

Error fixed and LocalStorage keys namespaced by purpose, i.e. `view_history/<UUID>`:
<img width="1254" alt="Screenshot 2025-05-30 at 07 32 29" src="https://github.com/user-attachments/assets/efe39dca-e5bd-44c4-b09b-2fdc088ea63e" />

## 🧪 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

- [x] Web (desktop)
- [ ] Web (mobile)
- [ ] Mobile (iOS)
- [ ] Mobile (Android)
- [ ] TV (Android)
- [ ] TV (Apple)

## 📦 Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist (copied from README)

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Squash your changes into a single clear and thoroughly descriptive commit, split changes into multiple commits only when it contributes to readability
- [ ] Reference the GitHub issue that you are contributing on in your commit title or body
- [x] Sign your commits, as this is required by the automated GitHub PR checks
- [x] Ensure that the changes adhere to the project code style and formatting rules by running `npx eslint .` and `npx prettier --check ../` from the `./OwnTube.tv/` directory (without errors/warnings)
- [x] Include links and illustrations in your pull request to make it easy to review
- [x] Request a review by @mykhailodanilenko, @ar9708 and @mblomdahl
