### PR TITLE
Fix download issues and enhance client authentication display

### DIFF
--- a/OwnTube.tv/app.config.ts
+++ b/OwnTube.tv/app.config.ts
@@ -107,14 +107,6 @@ export default {
       },
     ],
     "expo-asset",
-    [
-      "expo-media-library",
-      {
-        photosPermission: `Allow ${process.env.EXPO_PUBLIC_APP_NAME || "OwnTube.tv"} to access your media library.`,
-        savePhotosPermission: `Allow ${process.env.EXPO_PUBLIC_APP_NAME || "OwnTube.tv"} to save videos.`,
-        preventAutomaticLimitedAccessAlert: true,
-      },
-    ],
     "react-native-google-cast",
     [
       "./plugins/withReleaseSigningConfig.js",

--- a/OwnTube.tv/components/VideoContextMenu.tsx
+++ b/OwnTube.tv/components/VideoContextMenu.tsx
@@ -16,7 +16,7 @@ export const VideoContextMenu: React.FC<VideoContextMenuProps> = ({ handleOpenSe
   const { t } = useTranslation();
 
   return (
-    <TVFocusGuideHelper style={[styles.container, { backgroundColor: colors.black80 }]}>
+    <TVFocusGuideHelper style={[styles.container, { borderColor: colors.white25, backgroundColor: colors.black80 }]}>
       <Setting isSubmenuAvailable={false} onPress={handleOpenSettings} name={t("deviceCapabilityInfoTitle")} />
       {!!handleDownload && <Setting isSubmenuAvailable={false} onPress={handleDownload} name={t("downloadVideo")} />}
     </TVFocusGuideHelper>
@@ -26,8 +26,8 @@ export const VideoContextMenu: React.FC<VideoContextMenuProps> = ({ handleOpenSe
 const styles = StyleSheet.create({
   container: {
     borderRadius: borderRadius.radiusMd,
+    borderWidth: 0.5,
     paddingVertical: spacing.sm,
-    width: 256,
   },
 });
 

--- a/OwnTube.tv/components/VideoControlsOverlay/VideoControlsOverlay.tsx
+++ b/OwnTube.tv/components/VideoControlsOverlay/VideoControlsOverlay.tsx
@@ -203,7 +203,7 @@ const VideoControlsOverlay = ({
                         setIsContextMenuVisible(false);
                       }}
                       handleDownload={
-                        isDownloadAvailable
+                        isDownloadAvailable && !isLiveVideo
                           ? () => {
                               handleDownload();
                               setIsContextMenuVisible(false);

--- a/OwnTube.tv/components/shared/Picker/Picker.tsx
+++ b/OwnTube.tv/components/shared/Picker/Picker.tsx
@@ -39,13 +39,13 @@ const Picker = (props: PickerSelectProps) => {
         inputIOS: textStyle,
         inputAndroidContainer: containerStyle,
         inputAndroid: { ...textStyle, fontWeight: "500" },
+        iconContainer: {
+          pointerEvents: "none",
+        },
         ...props.style,
       }}
       Icon={() => (
-        <View
-          pointerEvents="none"
-          style={[styles.chevronContainer, { transform: [{ rotate: isPickerOpen ? "180deg" : "0deg" }] }]}
-        >
+        <View style={[styles.chevronContainer, { transform: [{ rotate: isPickerOpen ? "180deg" : "0deg" }] }]}>
           <IcoMoonIcon name="Chevron" size={24} color={colors.theme500} />
         </View>
       )}

--- a/OwnTube.tv/hooks/useDownloadVideo/useDownloadVideo.ts
+++ b/OwnTube.tv/hooks/useDownloadVideo/useDownloadVideo.ts
@@ -1,33 +1,29 @@
-import { Directory, Paths, File } from "expo-file-system/next";
 import { useGlobalSearchParams } from "expo-router";
 import { useState, useMemo, useEffect } from "react";
-import { useTranslation } from "react-i18next";
-import Toast from "react-native-toast-message";
 import { useGetVideoQuery } from "../../api";
 import { RootStackParams } from "../../app/_layout";
 import { useFullScreenModalContext } from "../../contexts";
 import { ROUTES } from "../../types";
-import { formatFileSize, sanitizeFileName } from "../../utils";
-import * as MediaLibrary from "expo-media-library";
+import { formatFileSize } from "../../utils";
+import { Linking } from "react-native";
 
 const useDownloadVideo = () => {
   const { toggleModal } = useFullScreenModalContext();
-  const { t } = useTranslation();
   const params = useGlobalSearchParams<RootStackParams[ROUTES.VIDEO]>();
   const [selectedFile, setSelectedFile] = useState<string>();
 
   const { data: videoData } = useGetVideoQuery({ id: params?.id });
 
   const pickerOptions = useMemo(() => {
-    if (videoData?.files && Number(videoData?.files?.length) > 0) {
-      return videoData.files.map((file) => ({
+    if (videoData?.streamingPlaylists && Number(videoData?.streamingPlaylists?.length) > 0) {
+      return videoData.streamingPlaylists[0].files.map((file) => ({
         label: `${file.resolution.label} (${formatFileSize(file.size)})`,
         value: file.fileDownloadUrl,
       }));
     }
 
-    if (videoData?.streamingPlaylists && Number(videoData?.streamingPlaylists?.length) > 0) {
-      return videoData.streamingPlaylists[0].files.map((file) => ({
+    if (videoData?.files && Number(videoData?.files?.length) > 0) {
+      return videoData.files.map((file) => ({
         label: `${file.resolution.label} (${formatFileSize(file.size)})`,
         value: file.fileDownloadUrl,
       }));
@@ -37,8 +33,12 @@ const useDownloadVideo = () => {
   }, [videoData]);
 
   useEffect(() => {
-    if (pickerOptions.length > 0) {
-      setSelectedFile(pickerOptions[0].value);
+    if (pickerOptions && pickerOptions.length > 1) {
+      const lowestQualityOption = pickerOptions.at(pickerOptions.at(-1)?.label.startsWith("Audio only") ? -2 : -1);
+
+      if (lowestQualityOption) {
+        setSelectedFile(lowestQualityOption.value);
+      }
     }
   }, [pickerOptions]);
 
@@ -46,33 +46,10 @@ const useDownloadVideo = () => {
     if (!selectedFile) {
       return;
     }
-    const destination = new Directory(Paths.cache, "videos");
 
-    try {
-      if (!destination.exists) {
-        destination.create();
-      }
+    toggleModal(false);
 
-      toggleModal(false);
-      Toast.show({ type: "info", text1: t("downloadStarted") });
-
-      const fileName = sanitizeFileName(videoData?.name) || "video";
-      const fileDownloadUrl = destination.uri + `/${fileName || "video"}.mp4`;
-
-      const output = await File.downloadFileAsync(selectedFile, new File(fileDownloadUrl));
-
-      await MediaLibrary.requestPermissionsAsync(true);
-
-      await MediaLibrary.saveToLibraryAsync(output.uri);
-
-      output.delete();
-
-      const ellipsizedFileName = fileName.length > 10 ? fileName.slice(0, 10) + "..." : fileName;
-      Toast.show({ type: "info", text1: t("downloadComplete", { fileName: ellipsizedFileName }) });
-    } catch (error) {
-      Toast.show({ type: "info", text1: t("downloadError"), props: { isError: true } });
-      console.error("Error downloading file:", error);
-    }
+    Linking.openURL(selectedFile);
   };
 
   return { handleDownloadFile, selectedFile, setSelectedFile, pickerOptions };

--- a/OwnTube.tv/hooks/useDownloadVideo/useDownloadVideo.web.ts
+++ b/OwnTube.tv/hooks/useDownloadVideo/useDownloadVideo.web.ts
@@ -12,15 +12,15 @@ const useDownloadVideo = () => {
   const { data: videoData } = useGetVideoQuery({ id: params?.id });
 
   const pickerOptions = useMemo(() => {
-    if (videoData?.files && Number(videoData?.files?.length) > 0) {
-      return videoData.files.map((file) => ({
+    if (videoData?.streamingPlaylists && Number(videoData?.streamingPlaylists?.length) > 0) {
+      return videoData.streamingPlaylists[0].files.map((file) => ({
         label: `${file.resolution.label} (${formatFileSize(file.size)})`,
         value: file.fileDownloadUrl,
       }));
     }
 
-    if (videoData?.streamingPlaylists && Number(videoData?.streamingPlaylists?.length) > 0) {
-      return videoData.streamingPlaylists[0].files.map((file) => ({
+    if (videoData?.files && Number(videoData?.files?.length) > 0) {
+      return videoData.files.map((file) => ({
         label: `${file.resolution.label} (${formatFileSize(file.size)})`,
         value: file.fileDownloadUrl,
       }));
@@ -30,8 +30,12 @@ const useDownloadVideo = () => {
   }, [videoData]);
 
   useEffect(() => {
-    if (pickerOptions.length > 0) {
-      setSelectedFile(pickerOptions[0].value);
+    if (pickerOptions && pickerOptions.length > 1) {
+      const lowestQualityOption = pickerOptions.at(pickerOptions.at(-1)?.label.startsWith("Audio only") ? -2 : -1);
+
+      if (lowestQualityOption) {
+        setSelectedFile(lowestQualityOption.value);
+      }
     }
   }, [pickerOptions]);
 

--- a/OwnTube.tv/locales/en.json
+++ b/OwnTube.tv/locales/en.json
@@ -173,5 +173,11 @@
   "download": "Download",
   "downloadStarted": "Your download has started, please wait...",
   "downloadComplete": "File {{fileName}} is downloaded!",
-  "downloadError": "Download error"
+  "downloadError": "Download error",
+  "currentAuth": "Current authentication:",
+  "currentAuthText": "User {{userName}} at {{backend}}, with two-factor {{_2fa}}, user session started at {{sessionStartedAt}}, updated at {{sessionUpdatedAt}}, {{expiredText}}, refresh token issued at {{refreshTokenIssuedAt}}",
+  "_2faOff": "off",
+  "_2faOn": "on",
+  "sessionExpired": "expired",
+  "sessionActive": "active"
 }

--- a/OwnTube.tv/locales/ru.json
+++ b/OwnTube.tv/locales/ru.json
@@ -172,5 +172,11 @@
   "downloadComplete": "Загрузка файла {{fileName}} завершена",
   "chooseQuality": "Выберите качество видео:",
   "download": "Скачать",
-  "downloadError": "Ошибка загрузки"
+  "downloadError": "Ошибка загрузки",
+  "currentAuth": "Текущая сессия:",
+  "currentAuthText": "Пользователь {{userName}} на {{backend}}, с {{_2fa}} двухфакторной аутентификацией, сессия создана в {{sessionStartedAt}}, обновлена в {{sessionUpdatedAt}}, {{expiredText}}, токен продления сессии выдан в {{refreshTokenIssuedAt}}",
+  "_2faOn": "включенной",
+  "_2faOff": "выключенной",
+  "sessionExpired": "истекла",
+  "sessionActive": "активна"
 }

--- a/OwnTube.tv/locales/sv.json
+++ b/OwnTube.tv/locales/sv.json
@@ -173,5 +173,11 @@
   "downloadVideo": "Ladda ner video",
   "chooseQuality": "Välj videokvalitet:",
   "download": "Ladda ner",
-  "downloadError": "Nedladdningsfel"
+  "downloadError": "Nedladdningsfel",
+  "currentAuth": "Aktuell autentisering:",
+  "_2faOn": "på",
+  "_2faOff": "av",
+  "sessionActive": "aktiv",
+  "sessionExpired": "utgången",
+  "currentAuthText": "Användare {{userName}} vid {{backend}}, med tvåfaktor {{_2fa}}, session startad {{sessionStartedAt}}, uppdaterad {{sessionUpdatedAt}}, {{expiredText}}, refresh token utfärdad {{refreshTokenIssuedAt}}"
 }

--- a/OwnTube.tv/locales/uk.json
+++ b/OwnTube.tv/locales/uk.json
@@ -172,5 +172,11 @@
   "downloadVideo": "Завантажити відео",
   "chooseQuality": "Виберіть якість відео:",
   "download": "Завантажити",
-  "downloadError": "Помилка завантаження"
+  "downloadError": "Помилка завантаження",
+  "currentAuth": "Поточна сесія:",
+  "currentAuthText": "Користувач {{userName}} на {{backend}}, з {{_2fa}} двофакторною аутентифікацією, сесію створено в {{sessionStartedAt}}, оновлено о {{sessionUpdatedAt}}, {{expiredText}}, токен продовження сесії виданий о {{refreshTokenIssuedAt}}",
+  "_2faOn": "увімкненою",
+  "_2faOff": "вимкненою",
+  "sessionExpired": "закінчилася",
+  "sessionActive": "активна"
 }

--- a/OwnTube.tv/package-lock.json
+++ b/OwnTube.tv/package-lock.json
@@ -37,7 +37,6 @@
         "expo-linear-gradient": "~14.0.2",
         "expo-linking": "~7.0.4",
         "expo-localization": "~16.0.1",
-        "expo-media-library": "~17.0.6",
         "expo-navigation-bar": "~4.0.7",
         "expo-router": "~4.0.16",
         "expo-screen-orientation": "~8.0.4",
@@ -9887,16 +9886,6 @@
       "peerDependencies": {
         "expo": "*",
         "react": "*"
-      }
-    },
-    "node_modules/expo-media-library": {
-      "version": "17.0.6",
-      "resolved": "https://registry.npmjs.org/expo-media-library/-/expo-media-library-17.0.6.tgz",
-      "integrity": "sha512-LUnfrddmee1xLOkyG2NN1l9xQbtvMX3fbM1brEGHg0SKSndvjod3FQdhTzZEYAariqW2RSxQR8v1IsheIoLQXg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "expo": "*",
-        "react-native": "*"
       }
     },
     "node_modules/expo-modules-autolinking": {

--- a/OwnTube.tv/package.json
+++ b/OwnTube.tv/package.json
@@ -74,8 +74,7 @@
     "ua-parser-js": "^1.0.38",
     "video.js": "^8.12.0",
     "zod": "^3.23.8",
-    "zustand": "^5.0.5",
-    "expo-media-library": "~17.0.6"
+    "zustand": "^5.0.5"
   },
   "devDependencies": {
     "@babel/core": "^7.24.0",

--- a/OwnTube.tv/screens/Otp/index.tsx
+++ b/OwnTube.tv/screens/Otp/index.tsx
@@ -71,7 +71,7 @@ export const Otp = () => {
     if (latestLoginMutation) {
       const loginResponse = await sendOtp({ ...latestLoginMutation, otp: formValues.otp });
 
-      const authSessionData = parseAuthSessionData(loginResponse, backend, latestLoginMutation.username);
+      const authSessionData = parseAuthSessionData(loginResponse, backend);
 
       if (loginResponse) {
         await addSession(backend, authSessionData);
@@ -83,6 +83,7 @@ export const Otp = () => {
           await updateSession(backend, {
             userInfoUpdatedAt: new Date().toISOString(),
             userInfoResponse,
+            email: userInfoResponse.email,
           });
         }
 

--- a/OwnTube.tv/screens/SignIn/index.tsx
+++ b/OwnTube.tv/screens/SignIn/index.tsx
@@ -94,7 +94,7 @@ export const SignIn = () => {
         throw e;
       }
 
-      const authSessionData = parseAuthSessionData(loginResponse, backend, formValues.username);
+      const authSessionData = parseAuthSessionData(loginResponse, backend);
 
       if (loginResponse) {
         await addSession(backend, authSessionData);
@@ -106,6 +106,7 @@ export const SignIn = () => {
           await updateSession(backend, {
             userInfoUpdatedAt: new Date().toISOString(),
             userInfoResponse,
+            email: userInfoResponse.email,
           });
         }
 

--- a/OwnTube.tv/utils/auth.ts
+++ b/OwnTube.tv/utils/auth.ts
@@ -4,7 +4,6 @@ import { UserLogin } from "@peertube/peertube-types";
 export const parseAuthSessionData = (
   loginResponse: UserLogin & { expires_in: number; refresh_token_expires_in: number },
   backend: string,
-  email?: string,
 ): Partial<AuthSession> => {
   const { getConfigByBackend } = useInstanceConfigStore.getState();
   const instanceConfig = getConfigByBackend(backend);
@@ -12,7 +11,6 @@ export const parseAuthSessionData = (
   const res = {
     backend,
     basePath: "/api/v1",
-    email,
     twoFactorEnabled: false,
     sessionCreatedAt: new Date().toISOString(),
     sessionUpdatedAt: new Date().toISOString(),
@@ -27,8 +25,6 @@ export const parseAuthSessionData = (
     refreshTokenExpiresIn:
       instanceConfig?.customizations?.loginRefreshTokenExpirationOverride ?? loginResponse.refresh_token_expires_in,
   };
-
-  if (!email) delete res.email;
 
   return res;
 };

--- a/OwnTube.tv/utils/common.test.tsx
+++ b/OwnTube.tv/utils/common.test.tsx
@@ -1,4 +1,4 @@
-import { capitalize, getAvailableVidsString, formatFileSize, sanitizeFileName } from "./common";
+import { capitalize, getAvailableVidsString, formatFileSize } from "./common";
 
 describe("capitalize", () => {
   it("capitalizes the first letter of a string", () => {
@@ -33,28 +33,5 @@ describe("formatFileSize", () => {
     expect(formatFileSize(1099511627776)).toBe("1 TB");
     expect(formatFileSize(1125899906842624)).toBe("1 PB");
     expect(formatFileSize(1536)).toBe("1.5 KB");
-  });
-});
-
-describe("sanitizeFileName", () => {
-  it("replaces spaces and invalid characters with underscores", () => {
-    expect(sanitizeFileName("my file.txt")).toBe("my_file.txt");
-    expect(sanitizeFileName("file@name!.mp4")).toBe("file_name_.mp4");
-    expect(sanitizeFileName("file   name")).toBe("file_name");
-    expect(sanitizeFileName("file__name")).toBe("file_name");
-  });
-
-  it("removes leading and trailing dots", () => {
-    expect(sanitizeFileName(".hiddenfile.")).toBe("hiddenfile");
-    expect(sanitizeFileName("..file..")).toBe("file");
-  });
-
-  it("returns null if name is undefined or empty", () => {
-    expect(sanitizeFileName(undefined)).toBeNull();
-    expect(sanitizeFileName("")).toBeNull();
-  });
-
-  it("trims the result", () => {
-    expect(sanitizeFileName("  file name  ")).toBe("file_name");
   });
 });

--- a/OwnTube.tv/utils/common.ts
+++ b/OwnTube.tv/utils/common.ts
@@ -17,15 +17,3 @@ export function formatFileSize(bytes: number): string {
 
   return `${size} ${units[unitIndex]}`;
 }
-
-export function sanitizeFileName(name?: string) {
-  if (!name) return null;
-
-  return name
-    .trim()
-    .replace(/\s+/g, "_")
-    .replace(/[^a-zA-Z0-9_\-.]/g, "_")
-    .replace(/_+/g, "_")
-    .replace(/^\.+/, "")
-    .replace(/\.+$/, "");
-}


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description
Resolve download issues by refining the download logic and improve the settings view to include current authentication details.

Seems like the easier solution with downloading through the browser on mobile platforms has worked

<!-- Describe your changes in detail -->

## 📄 Motivation and Context
#402, #401, #400, #399, #398, #395 
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## 🧪 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

- [x] Web (desktop)
- [x] Web (mobile)
- [x] Mobile (iOS)
- [x] Mobile (Android)
- [ ] TV (Android)
- [ ] TV (Apple)

## 📦 Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist (copied from README)

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Squash your changes into a single clear and thoroughly descriptive commit, split changes into multiple commits only when it contributes to readability
- [x] Reference the GitHub issue that you are contributing on in your commit title or body
- [x] Sign your commits, as this is required by the automated GitHub PR checks
- [x] Ensure that the changes adhere to the project code style and formatting rules by running `npx eslint .` and `npx prettier --check ../` from the `./OwnTube.tv/` directory (without errors/warnings)
- [x] Include links and illustrations in your pull request to make it easy to review
- [x] Request a review by @mykhailodanilenko, @ar9708 and @mblomdahl
