### PR TITLE
Add togglable horizontal presentations for mobile portrait view

### DIFF
--- a/OwnTube.tv/components/CategoryView.tsx
+++ b/OwnTube.tv/components/CategoryView.tsx
@@ -5,6 +5,7 @@ import { ROUTES } from "../types";
 import { useLocalSearchParams } from "expo-router";
 import { getAvailableVidsString } from "../utils";
 import { ListSeparator } from "../screens/HomeScreen/components";
+import { useAppConfigContext } from "../contexts";
 
 interface CategoryViewProps {
   category: { name: string; id: number };
@@ -22,6 +23,8 @@ export const CategoryView = ({ category }: CategoryViewProps) => {
     },
     uniqueQueryKey: `category-${category.id}`,
   });
+  const { currentInstanceConfig } = useAppConfigContext();
+  const showHorizontalScrollableLists = currentInstanceConfig?.customizations?.homeUseHorizontalListsForMobilePortrait;
 
   if (!data?.data?.length && !isLoading) {
     return null;
@@ -30,6 +33,7 @@ export const CategoryView = ({ category }: CategoryViewProps) => {
   return (
     <>
       <VideoGrid
+        scrollable={showHorizontalScrollableLists}
         reduceHeaderContrast
         refetch={refetch}
         isError={isError}

--- a/OwnTube.tv/components/ChannelView.tsx
+++ b/OwnTube.tv/components/ChannelView.tsx
@@ -7,6 +7,7 @@ import { useLocalSearchParams } from "expo-router";
 import { RootStackParams } from "../app/_layout";
 import { getAvailableVidsString } from "../utils";
 import { ListSeparator } from "../screens/HomeScreen/components";
+import { useAppConfigContext } from "../contexts";
 
 interface ChannelViewProps {
   channel: VideoChannel;
@@ -16,6 +17,8 @@ export const ChannelView = ({ channel }: ChannelViewProps) => {
   const { backend } = useLocalSearchParams<RootStackParams[ROUTES.CHANNELS]>();
   const { data, isLoading, isError, refetch } = useGetChannelVideosQuery(channel.name);
   const { t } = useTranslation();
+  const { currentInstanceConfig } = useAppConfigContext();
+  const showHorizontalScrollableLists = currentInstanceConfig?.customizations?.homeUseHorizontalListsForMobilePortrait;
 
   if (!data?.data?.length && !isLoading) {
     return null;
@@ -24,6 +27,7 @@ export const ChannelView = ({ channel }: ChannelViewProps) => {
   return (
     <>
       <VideoGrid
+        scrollable={showHorizontalScrollableLists}
         reduceHeaderContrast
         isError={isError}
         refetch={refetch}

--- a/OwnTube.tv/components/VideoGrid/VideoGrid.tsx
+++ b/OwnTube.tv/components/VideoGrid/VideoGrid.tsx
@@ -40,6 +40,7 @@ export interface VideoGridProps {
   isHeaderHidden?: boolean;
   reduceHeaderContrast?: boolean;
   isTVActionCardHidden?: boolean;
+  scrollable?: boolean;
 }
 
 export const VideoGrid = ({
@@ -58,6 +59,7 @@ export const VideoGrid = ({
   isHeaderHidden = false,
   reduceHeaderContrast = false,
   isTVActionCardHidden = false,
+  scrollable = false,
 }: VideoGridProps) => {
   const { backend } = useLocalSearchParams<RootStackParams[ROUTES.INDEX]>();
   const { colors } = useTheme();
@@ -82,7 +84,7 @@ export const VideoGrid = ({
       );
     }
 
-    const isShowMoreBtnVisible = !!handleShowMore && (!Platform.isTV || customPresentation === "list");
+    const isShowMoreBtnVisible = !!handleShowMore && (!Platform.isTV || customPresentation === "list") && !scrollable;
     const handleShowMorePress = () => {
       (customPresentation === "grid" ? gridContentRef : listContentRef).current?.focusLastItem();
       handleShowMore?.();
@@ -95,6 +97,7 @@ export const VideoGrid = ({
         )}
         {customPresentation === "grid" ? (
           <VideoGridContent
+            scrollable={scrollable}
             tvActionCardProps={{
               isHidden: isTVActionCardHidden,
               isLoading: isLoadingMore,
@@ -157,7 +160,14 @@ export const VideoGrid = ({
               <Image style={styles.image} source={{ uri: `https://${backend}${channelLogoUri}` }} />
             </View>
           )}
-          <View style={{ flexDirection: isMobile ? "column" : "row", gap: spacing.lg, flex: 1 }}>
+          <View
+            style={{
+              flexDirection: isMobile && !scrollable ? "column" : "row",
+              gap: spacing.lg,
+              flex: 1,
+              flexWrap: "wrap",
+            }}
+          >
             <View style={styles.headerTextContainer}>
               {icon && <IcoMoonIcon size={24} name={icon} color={colors.theme900} />}
               {title && (

--- a/OwnTube.tv/components/VideoGrid/styles.css
+++ b/OwnTube.tv/components/VideoGrid/styles.css
@@ -5,3 +5,12 @@
   row-gap: 40px;
   width: 100%;
 }
+.grid-container-scrollable {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: 277px;
+  grid-template-rows: 1fr;
+  column-gap: 16px;
+  overflow-x: auto;
+  width: 100%;
+}

--- a/OwnTube.tv/instanceConfigs.ts
+++ b/OwnTube.tv/instanceConfigs.ts
@@ -10,6 +10,7 @@ const customizationsSchema = z
     homeHideChannelsOverview: z.boolean(),
     homeHideCategoriesOverview: z.boolean(),
     homeHidePlaylistsOverview: z.boolean(),
+    homeUseHorizontalListsForMobilePortrait: z.boolean(),
     pageDefaultTheme: colorSchemeNameSchema,
     menuHideHistoryButton: z.boolean(),
     menuHideChannelsButton: z.boolean(),

--- a/OwnTube.tv/public/featured-instances.json5
+++ b/OwnTube.tv/public/featured-instances.json5
@@ -38,6 +38,7 @@
     logoUrl: "https://owntube-tv.github.io/web-client/logos/video.blender.org.jpg",
     customizations: {
       pageTitle: "Blender Tube",
+      homeUseHorizontalListsForMobilePortrait: true,
       menuExternalLinks: [
         {
           label: "Website",
@@ -241,6 +242,7 @@
         "18384",
       ],
       playlistsShowHiddenButton: true,
+      homeUseHorizontalListsForMobilePortrait: true,
       homeLatestPublishedVideoCount: 24,
       homeRecentlyWatchedVideoCount: 4,
       homeHideChannelsOverview: true,

--- a/OwnTube.tv/screens/HomeScreen/components/LatestVideosView.tsx
+++ b/OwnTube.tv/screens/HomeScreen/components/LatestVideosView.tsx
@@ -16,6 +16,7 @@ export const LatestVideosView = () => {
     return data?.pages?.flatMap(({ data }) => data.flat());
   }, [data]);
   const { t } = useTranslation();
+  const showHorizontalScrollableLists = currentInstanceConfig?.customizations?.homeUseHorizontalListsForMobilePortrait;
 
   return (
     <>
@@ -29,6 +30,7 @@ export const LatestVideosView = () => {
         handleShowMore={hasNextPage ? fetchNextPage : undefined}
         link={{ text: t("showMore") }}
         isTVActionCardHidden={!hasNextPage}
+        scrollable={showHorizontalScrollableLists}
       />
       <ListSeparator />
     </>

--- a/OwnTube.tv/screens/HomeScreen/index.tsx
+++ b/OwnTube.tv/screens/HomeScreen/index.tsx
@@ -72,11 +72,20 @@ export const HomeScreen = () => {
     );
   }, [viewHistory, currentInstanceConfig]);
 
+  const showHorizontalScrollableLists = currentInstanceConfig?.customizations?.homeUseHorizontalListsForMobilePortrait;
+
   const sections = useMemo(() => {
     return [
       {
         title: t("liveStreams"),
-        renderItem: () => <VideoGrid isTVActionCardHidden={true} isHeaderHidden data={liveVideosData} />,
+        renderItem: () => (
+          <VideoGrid
+            scrollable={showHorizontalScrollableLists}
+            isTVActionCardHidden={true}
+            isHeaderHidden
+            data={liveVideosData}
+          />
+        ),
         data: ["dataItemPlaceholder"],
         isVisible: Number(liveVideosData?.length) > 0,
       },
@@ -91,6 +100,7 @@ export const HomeScreen = () => {
         link: { text: t("viewHistory"), route: `/${ROUTES.HISTORY}` },
         renderItem: () => (
           <VideoGrid
+            scrollable={showHorizontalScrollableLists}
             link={
               Platform.isTV
                 ? { text: t("viewHistory"), href: { pathname: `/${ROUTES.HISTORY}`, params: { backend } } }
@@ -130,7 +140,17 @@ export const HomeScreen = () => {
         isVisible: !currentInstanceConfig?.customizations?.homeHideCategoriesOverview && !!categories?.length,
       },
     ].filter(({ isVisible }) => isVisible);
-  }, [t, historyData, backend, playlistsData, channels, categories, currentInstanceConfig, liveVideosData]);
+  }, [
+    t,
+    historyData,
+    backend,
+    playlistsData,
+    channels,
+    categories,
+    currentInstanceConfig,
+    liveVideosData,
+    showHorizontalScrollableLists,
+  ]);
 
   const [refreshing, setRefreshing] = useState(false);
 

--- a/OwnTube.tv/screens/Playlists/components/PlaylistVideosView.tsx
+++ b/OwnTube.tv/screens/Playlists/components/PlaylistVideosView.tsx
@@ -5,6 +5,7 @@ import { useLocalSearchParams } from "expo-router";
 import { useTranslation } from "react-i18next";
 import { getAvailableVidsString } from "../../../utils";
 import { ListSeparator } from "../../HomeScreen/components";
+import { useAppConfigContext } from "../../../contexts";
 
 interface PlaylistVideosViewProps {
   id: number;
@@ -18,6 +19,8 @@ export const PlaylistVideosView = ({ id, title, channel, location = "other" }: P
   const { data, isLoading, isError, refetch } = useGetPlaylistVideosQuery(id);
   const { t } = useTranslation();
   const isOnHomePage = location === "home";
+  const { currentInstanceConfig } = useAppConfigContext();
+  const showHorizontalScrollableLists = currentInstanceConfig?.customizations?.homeUseHorizontalListsForMobilePortrait;
 
   if ((!data?.data?.length || !data?.total) && !isLoading) {
     return null;
@@ -27,6 +30,7 @@ export const PlaylistVideosView = ({ id, title, channel, location = "other" }: P
     <>
       <VideoGrid
         variant="playlist"
+        scrollable={showHorizontalScrollableLists && isOnHomePage}
         reduceHeaderContrast={isOnHomePage}
         isError={isError}
         refetch={refetch}


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description
This PR adds togglable horizontal lists to homepage presentation options.

<!-- Describe your changes in detail -->

## 📄 Motivation and Context
closes #405
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## 🧪 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

- [ ] Web (desktop)
- [x] Web (mobile)
- [x] Mobile (iOS)
- [x] Mobile (Android)
- [ ] TV (Android)
- [ ] TV (Apple)

## 📦 Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist (copied from README)

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Squash your changes into a single clear and thoroughly descriptive commit, split changes into multiple commits only when it contributes to readability
- [x] Reference the GitHub issue that you are contributing on in your commit title or body
- [x] Sign your commits, as this is required by the automated GitHub PR checks
- [x] Ensure that the changes adhere to the project code style and formatting rules by running `npx eslint .` and `npx prettier --check ../` from the `./OwnTube.tv/` directory (without errors/warnings)
- [x] Include links and illustrations in your pull request to make it easy to review
- [x] Request a review by @mykhailodanilenko, @ar9708 and @mblomdahl
