### PR TITLE
Add video loading and buffering states, proper quality switching for hls, clean up old view history code, add timestamp override if present in history

### DIFF
--- a/OwnTube.tv/components/PlaybackSettingsPopup.tsx
+++ b/OwnTube.tv/components/PlaybackSettingsPopup.tsx
@@ -18,7 +18,7 @@ interface PlaybackSettingsPopupProps {
   selectedSpeed: number;
   handleSetSpeed: (speed: number) => void;
   selectedQuality: string;
-  handleSetQuality: (quality: string) => void;
+  handleSetQuality?: (quality: string) => void;
   onSelectOption?: () => void;
   handleSetCCLang?: (lang: string) => void;
   selectedCCLang?: string;
@@ -149,7 +149,15 @@ export const PlaybackSettingsPopup = ({
                 },
               ]
             : []),
-          { name: t("quality"), id: "quality", state: qualityOptions?.find(({ id }) => selectedQuality === id)?.label },
+          ...(handleSetQuality
+            ? [
+                {
+                  name: t("quality"),
+                  id: "quality",
+                  state: qualityOptions?.find(({ id }) => selectedQuality === id)?.label,
+                },
+              ]
+            : []),
         ] as const
       ).map(({ name, id, state }) => (
         <Setting key={id} name={name} state={state} onPress={() => setSelectedScreen(id as keyof typeof screens)} />
@@ -177,7 +185,7 @@ export const PlaybackSettingsPopup = ({
           {qualityOptions?.map(({ id, label }) => (
             <Option
               onPress={(quality: string) => {
-                handleSetQuality(quality);
+                handleSetQuality?.(quality);
                 onSelectOption?.();
               }}
               key={id}
@@ -206,7 +214,7 @@ export const PlaybackSettingsPopup = ({
         </>
       ),
     };
-  }, [colors, selectedSpeed, selectedQuality, videoData, t, selectedCCLang, handleSetCCLang]);
+  }, [colors, selectedSpeed, selectedQuality, videoData, t, selectedCCLang, handleSetCCLang, handleSetQuality]);
 
   return (
     <TVFocusGuideHelper style={[styles.container, { backgroundColor: colors.black80 }]}>

--- a/OwnTube.tv/components/VideoControlsOverlay/VideoControlsOverlay.tsx
+++ b/OwnTube.tv/components/VideoControlsOverlay/VideoControlsOverlay.tsx
@@ -1,5 +1,5 @@
 import { PropsWithChildren } from "react";
-import { Platform, Pressable, StyleSheet, View } from "react-native";
+import { ActivityIndicator, Platform, Pressable, StyleSheet, View } from "react-native";
 import { Typography } from "../Typography";
 import { getHumanReadableDuration } from "../../utils";
 import { VolumeControl } from "./components/VolumeControl";
@@ -55,7 +55,7 @@ export interface VideoControlsOverlayProps {
   handleSetSpeed: (speed: number) => void;
   speed: number;
   selectedQuality: string;
-  handleSetQuality: (quality: string) => void;
+  handleSetQuality?: (quality: string) => void;
   isWebAirPlayAvailable?: boolean;
   isChromeCastAvailable?: boolean;
   castState?: "airPlay" | "chromecast";
@@ -69,6 +69,7 @@ export interface VideoControlsOverlayProps {
   isWaitingForLive: boolean;
   hlsAutoQuality?: number;
   isDownloadAvailable?: boolean;
+  isLoading: boolean;
 }
 
 const VideoControlsOverlay = ({
@@ -115,6 +116,7 @@ const VideoControlsOverlay = ({
   isWaitingForLive,
   hlsAutoQuality,
   isDownloadAvailable,
+  isLoading,
 }: PropsWithChildren<VideoControlsOverlayProps>) => {
   const {
     isSeekBarFocused,
@@ -216,7 +218,11 @@ const VideoControlsOverlay = ({
               </View>
             </LinearGradient>
           </Animated.View>
-          {isMobile && (
+          {isLoading ? (
+            <View style={styles.playbackControlsContainer}>
+              <ActivityIndicator size="large" />
+            </View>
+          ) : isMobile ? (
             <AnimatedPressable
               entering={FadeIn}
               exiting={FadeOut}
@@ -235,7 +241,7 @@ const VideoControlsOverlay = ({
               )}
               {!isLiveVideo && <PlayerButton onPress={() => handleFF(30)} icon="Fast-forward-30" />}
             </AnimatedPressable>
-          )}
+          ) : null}
           <Animated.View
             exiting={SlideOutDown}
             style={[styles.animatedBottomContainer, { paddingBottom: insets.bottom }]}
@@ -289,10 +295,16 @@ const VideoControlsOverlay = ({
                     <View style={styles.bottomRowControlsContainer}>
                       {!isMobile && (
                         <>
-                          <PlayerButton
-                            onPress={shouldReplay ? handleReplay : handlePlayPause}
-                            icon={centralIconName}
-                          />
+                          {isLoading ? (
+                            <View style={{ padding: 12 }}>
+                              <ActivityIndicator size={24} />
+                            </View>
+                          ) : (
+                            <PlayerButton
+                              onPress={shouldReplay ? handleReplay : handlePlayPause}
+                              icon={centralIconName}
+                            />
+                          )}
                           {!isLiveVideo && (
                             <>
                               <PlayerButton onPress={() => handleRW(15)} icon="Rewind-15" />

--- a/OwnTube.tv/components/VideoControlsOverlay/VideoControlsOverlay.tv.tsx
+++ b/OwnTube.tv/components/VideoControlsOverlay/VideoControlsOverlay.tv.tsx
@@ -8,6 +8,7 @@ import {
   TVFocusGuideView,
   Platform,
   BackHandler,
+  ActivityIndicator,
 } from "react-native";
 import { Typography } from "../Typography";
 import { getHumanReadableDuration } from "../../utils";
@@ -73,6 +74,7 @@ const VideoControlsOverlay = ({
   isCCAvailable,
   isLiveVideo,
   isWaitingForLive,
+  isLoading,
 }: PropsWithChildren<VideoControlsOverlayProps>) => {
   const {
     isSeekBarFocused,
@@ -271,7 +273,9 @@ const VideoControlsOverlay = ({
                   icon="Rewind-15"
                 />
               )}
-              {!isWaitingForLive && (
+              {isLoading ? (
+                <ActivityIndicator size={"large"} />
+              ) : !isWaitingForLive ? (
                 <PlayerButton
                   scale={INTERFACE_SCALE}
                   nextFocusUp={backRef}
@@ -280,7 +284,7 @@ const VideoControlsOverlay = ({
                   icon={centralIconName}
                   nextFocusDown={isLiveVideo ? settingsRef.current : undefined}
                 />
-              )}
+              ) : null}
               {!isLiveVideo && (
                 <PlayerButton
                   scale={INTERFACE_SCALE}

--- a/OwnTube.tv/components/VideoControlsOverlay/components/modals/Share/Share.tsx
+++ b/OwnTube.tv/components/VideoControlsOverlay/components/modals/Share/Share.tsx
@@ -59,7 +59,12 @@ const Share = ({ onClose, titleKey, staticLink }: ShareProps) => {
         containerStyle={styles.modalContainer}
       >
         <ScrollView>
-          <Input buttonText={copyButtonText} readOnly value={staticLink || link} handleButtonPress={handleCopy} />
+          <Input
+            buttonText={copyButtonText}
+            readOnly
+            value={(staticLink || link).replace(/^https?:\/\//, "")}
+            handleButtonPress={handleCopy}
+          />
           <Spacer height={spacing.xl} />
           {isTimestampShown && (
             <>

--- a/OwnTube.tv/components/VideoView/styles.ts
+++ b/OwnTube.tv/components/VideoView/styles.ts
@@ -18,6 +18,17 @@ export const styles = StyleSheet.create({
     flex: 1,
     justifyContent: "center",
   },
+  liveStreamAnnouncementContainer: {
+    alignItems: "center",
+    bottom: 0,
+    flex: 1,
+    justifyContent: "center",
+    left: 0,
+    position: "absolute",
+    right: 0,
+    top: 0,
+    zIndex: 1,
+  },
   liveStreamOfflineOverlay: { alignItems: "center", flex: 1, justifyContent: "center", zIndex: 1 },
   liveStreamPoster: { bottom: 0, flex: 1, left: 0, position: "absolute", right: 0, top: 0 },
   opacityOverlay: {
@@ -29,5 +40,6 @@ export const styles = StyleSheet.create({
     right: 0,
     top: 0,
   },
-  videoWrapper: { flex: 1, height: "100%", width: "100%" },
+  previewImage: { bottom: 0, flex: 1, left: 0, position: "absolute", right: 0, top: 0 },
+  videoWrapper: { flex: 1, height: "100%", pointerEvents: "none", width: "100%", zIndex: 1 },
 });

--- a/OwnTube.tv/hooks/useViewHistory.test.tsx
+++ b/OwnTube.tv/hooks/useViewHistory.test.tsx
@@ -15,13 +15,10 @@ describe("useViewHistory", () => {
 
   it("should get view history sorted by last viewed date and limited by the specified number", async () => {
     (readFromAsyncStorage as jest.Mock).mockResolvedValueOnce(["uuid1", "uuid2"]);
-    // First call for new format keys
     (multiGetFromAsyncStorage as jest.Mock).mockResolvedValueOnce([
       ["view_history/uuid1", JSON.stringify({ lastViewedAt: 123 })],
       ["view_history/uuid2", JSON.stringify({ lastViewedAt: 125 })],
     ]);
-    // Second call for old format keys (fallback)
-    (multiGetFromAsyncStorage as jest.Mock).mockResolvedValueOnce([]);
 
     const { result } = renderHook(() => useViewHistory({ enabled: true, maxItems: 2 }), { wrapper });
 
@@ -46,7 +43,6 @@ describe("useViewHistory", () => {
       firstViewedAt: 1234,
       lastViewedAt: 1234,
       name: "big bug buggy",
-      timestamp: 0,
       uuid: "uuid3",
     });
   });
@@ -59,7 +55,6 @@ describe("useViewHistory", () => {
         firstViewedAt: 1234,
         lastViewedAt: 1234,
         name: "big bug buggy",
-        timestamp: 0,
         uuid: "uuid3",
       });
 
@@ -92,8 +87,7 @@ describe("useViewHistory", () => {
       "view_history/uuid1",
       "view_history/uuid2",
     ]);
-    expect(deleteFromAsyncStorage).toHaveBeenNthCalledWith(2, ["uuid3", "uuid1", "uuid2"]);
-    expect(deleteFromAsyncStorage).toHaveBeenNthCalledWith(3, [STORAGE.VIEW_HISTORY]);
+    expect(deleteFromAsyncStorage).toHaveBeenNthCalledWith(2, [STORAGE.VIEW_HISTORY]);
   });
 
   it("should remove history for a specified backend", async () => {
@@ -111,7 +105,6 @@ describe("useViewHistory", () => {
     });
 
     expect(deleteFromAsyncStorage).toHaveBeenNthCalledWith(1, ["view_history/uuid1", "view_history/uuid3"]);
-    expect(deleteFromAsyncStorage).toHaveBeenNthCalledWith(2, ["uuid1", "uuid3"]);
     expect(writeToAsyncStorage).toHaveBeenCalledWith(STORAGE.VIEW_HISTORY, ["uuid2"]);
   });
 });

--- a/OwnTube.tv/package-lock.json
+++ b/OwnTube.tv/package-lock.json
@@ -63,7 +63,7 @@
         "react-native-svg": "^15.5.0",
         "react-native-toast-message": "^2.2.0",
         "react-native-uuid": "^2.0.3",
-        "react-native-video": "^6.10.0",
+        "react-native-video": "^6.16.1",
         "react-native-web": "~0.19.6",
         "react-qr-code": "^2.0.15",
         "react-test-renderer": "18.2.0",
@@ -16663,9 +16663,9 @@
       }
     },
     "node_modules/react-native-video": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/react-native-video/-/react-native-video-6.10.0.tgz",
-      "integrity": "sha512-NyDnpSBRJkj7TxMku2dEys54qKynW/l9kSPCVvayyqXWrc24cxHhLvAaxORdJDb6tS4FhUbR8tFIoOY65/XKZg==",
+      "version": "6.16.1",
+      "resolved": "https://registry.npmjs.org/react-native-video/-/react-native-video-6.16.1.tgz",
+      "integrity": "sha512-+G6tVVGbwFqNTyPivqb+PhQzWr5OudDQ1dgvBNyBRAgcS8rOcbwuS6oX+m8cxOsXHn1UT9ofQnjQEwkGOsvomg==",
       "license": "MIT",
       "peerDependencies": {
         "react": "*",

--- a/OwnTube.tv/package.json
+++ b/OwnTube.tv/package.json
@@ -67,7 +67,7 @@
     "react-native-svg": "^15.5.0",
     "react-native-toast-message": "^2.2.0",
     "react-native-uuid": "^2.0.3",
-    "react-native-video": "^6.10.0",
+    "react-native-video": "^6.16.1",
     "react-native-web": "~0.19.6",
     "react-qr-code": "^2.0.15",
     "react-test-renderer": "18.2.0",

--- a/OwnTube.tv/screens/VideoScreen/index.tsx
+++ b/OwnTube.tv/screens/VideoScreen/index.tsx
@@ -91,12 +91,7 @@ export const VideoScreen = () => {
         hlsStream = data.streamingPlaylists[0];
       }
 
-      const streamByQuality = hlsStream.files.find(({ resolution }) => String(resolution.id) === quality);
-
-      if (!streamByQuality) return hlsStream.playlistUrl;
-
-      // fallback to .replace() is for older instances without playlistUrl support
-      return streamByQuality.playlistUrl || streamByQuality.fileUrl.replace(`-fragmented.mp4`, ".m3u8");
+      return hlsStream.playlistUrl;
     }
 
     const webVideoFileByQuality = data.files?.find(({ resolution }) => String(resolution.id) === quality);


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description
In this PR the following changes can be observed:

- Quality switching on HLS videos is now the proper implementation, instead of switching to a different media playlist the app now switches hls renditions declared in the master playlist, thus fixing the missing subtitles problem;
- On iOS and Safari hls quality switching is turned off because of Apple's limitations on hls rendition switching;
- Cleaned up old code for view history handling (old localstorage keys)
- Added a loading indicator for video loading and buffering states, will test in various network conditions to test
- Added saving playback position on refresh, now the playback position saved in view history has precedence over the timestamp from URL params

<!-- Describe your changes in detail -->

## 📄 Motivation and Context
#407, #408, #409
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## 🧪 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

- [x] Web (desktop)
- [x] Web (mobile)
- [x] Mobile (iOS)
- [x] Mobile (Android)
- [ ] TV (Android)
- [x] TV (Apple)

## 📦 Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist (copied from README)

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Squash your changes into a single clear and thoroughly descriptive commit, split changes into multiple commits only when it contributes to readability
- [x] Reference the GitHub issue that you are contributing on in your commit title or body
- [x] Sign your commits, as this is required by the automated GitHub PR checks
- [x] Ensure that the changes adhere to the project code style and formatting rules by running `npx eslint .` and `npx prettier --check ../` from the `./OwnTube.tv/` directory (without errors/warnings)
- [x] Include links and illustrations in your pull request to make it easy to review
- [x] Request a review by @mykhailodanilenko, @ar9708 and @mblomdahl
