### PR TITLE
Add playback event, use PostHog session ID in PeerTube watch tracking

### DIFF
--- a/OwnTube.tv/api/queries/videos.ts
+++ b/OwnTube.tv/api/queries/videos.ts
@@ -8,10 +8,10 @@ import { SOURCES } from "../../types";
 import { getLocalData, retry } from "../helpers";
 
 import { QUERY_KEYS } from "../constants";
-import { useAppConfigContext } from "../../contexts";
 import Constants from "expo-constants";
 import * as Device from "expo-device";
 import { getDeviceTypeForVideoView } from "../../utils";
+import { postHogInstance } from "../../diagnostics";
 
 export const useGetVideosQuery = <TResult = GetVideosVideo[]>({
   enabled = true,
@@ -111,7 +111,6 @@ export const useGetVideoQuery = <TResult = Video>({
 
 export const usePostVideoViewMutation = () => {
   const { backend } = useLocalSearchParams<RootStackParams["index"]>();
-  const { sessionId } = useAppConfigContext();
 
   return useMutation({
     mutationFn: async ({
@@ -126,7 +125,7 @@ export const usePostVideoViewMutation = () => {
       return await ApiServiceImpl.postVideoView(backend!, videoId!, {
         currentTime,
         viewEvent,
-        sessionId,
+        sessionId: postHogInstance.getSessionId(),
         client: Constants.expoConfig?.name ?? "OwnTube",
         device: getDeviceTypeForVideoView(Device.deviceType),
         operatingSystem: Device.osName ?? undefined,

--- a/OwnTube.tv/components/VideoView/VideoView.web.tsx
+++ b/OwnTube.tv/components/VideoView/VideoView.web.tsx
@@ -91,6 +91,17 @@ const VideoView = ({
   const { getViewHistoryEntryByUuid } = useViewHistory();
   const { captureDiagnosticsEvent, captureError } = useCustomDiagnosticsEvents();
   const { handleTimeUpdate } = useWatchedDuration(playbackStatus.duration);
+  const capturePlaybackEvent = (viewEvent: "watch" | "seek") => {
+    captureDiagnosticsEvent(CustomPostHogEvents.VideoPlayback, {
+      videoId: videoData?.uuid,
+      currentTime: playbackStatus.position,
+      isFullscreen,
+      externalPlaybackState: isChromecastConnected ? "chromecast" : undefined,
+      captionsEnabled: isCCShown,
+      captionsLanguage: selectedCCLang,
+      viewEvent,
+    });
+  };
 
   const { colors } = useTheme();
 
@@ -148,6 +159,7 @@ const VideoView = ({
       targetTime: getHumanReadableDuration(updatedTime * 1000),
       targetPercentage: Math.trunc((updatedTime / playbackStatus.duration) * 100),
     });
+    capturePlaybackEvent("seek");
   };
 
   const handleFF = (seconds: number) => {
@@ -162,6 +174,7 @@ const VideoView = ({
       targetTime: getHumanReadableDuration(updatedTime * 1000),
       targetPercentage: Math.trunc((updatedTime / playbackStatus.duration) * 100),
     });
+    capturePlaybackEvent("seek");
   };
 
   const toggleMute = () => {
@@ -192,6 +205,7 @@ const VideoView = ({
       targetTime: getHumanReadableDuration(position * 1000),
       targetPercentage: Math.trunc((position / playbackStatus.duration) * 100),
     });
+    capturePlaybackEvent("seek");
   };
 
   const options = {
@@ -413,6 +427,7 @@ const VideoView = ({
     if (currentTimeInt % 5 === 0 && currentTimeInt !== lastReportedTime.current) {
       lastReportedTime.current = currentTimeInt;
       postVideoView({ videoId: videoData?.uuid, currentTime: currentTimeInt });
+      capturePlaybackEvent("watch");
     }
   }, [playbackStatus.position]);
 

--- a/OwnTube.tv/contexts/AppConfigContext.tsx
+++ b/OwnTube.tv/contexts/AppConfigContext.tsx
@@ -23,8 +23,6 @@ import { useTranslation } from "react-i18next";
 import { useGlobalSearchParams } from "expo-router";
 import { readFromAsyncStorage, writeToAsyncStorage } from "../utils";
 import { STORAGE } from "../types";
-import { Platform } from "react-native";
-import uuid from "react-native-uuid";
 import { useQueryClient } from "@tanstack/react-query";
 import { GLOBAL_QUERY_STALE_TIME } from "../api";
 import { useInstanceConfigStore } from "../store";
@@ -37,7 +35,6 @@ interface IAppConfigContext {
   deviceCapabilities: DeviceCapabilities;
   featuredInstances?: InstanceConfig[];
   primaryBackend?: string;
-  sessionId: string;
   sessionCCLocale: string;
   updateSessionCCLocale: (locale: string) => void;
   currentInstanceConfig?: InstanceConfig;
@@ -115,23 +112,6 @@ export const AppConfigContextProvider = ({ children }: PropsWithChildren) => {
     });
   }, [currentInstanceConfig, queryClient]);
 
-  const [sessionId, setSessionId] = useState<string>("");
-
-  useEffect(() => {
-    if (Platform.OS === "web" && typeof window !== "undefined" && window.sessionStorage) {
-      let storedSessionId = window.sessionStorage.getItem("owntube_session_id");
-
-      if (!storedSessionId) {
-        storedSessionId = uuid.v4();
-        window.sessionStorage.setItem("owntube_session_id", storedSessionId);
-      }
-
-      setSessionId(storedSessionId);
-    } else {
-      setSessionId(uuid.v4());
-    }
-  }, []);
-
   useEffect(() => {
     readFromAsyncStorage(STORAGE.DEBUG_MODE).then((debugMode) => {
       setIsDebugMode(debugMode === "true");
@@ -146,7 +126,6 @@ export const AppConfigContextProvider = ({ children }: PropsWithChildren) => {
         deviceCapabilities,
         featuredInstances,
         primaryBackend,
-        sessionId,
         sessionCCLocale,
         updateSessionCCLocale,
         currentInstanceConfig,

--- a/OwnTube.tv/diagnostics/constants.ts
+++ b/OwnTube.tv/diagnostics/constants.ts
@@ -34,6 +34,7 @@ export enum CustomPostHogEvents {
   InstanceSearchTextChanged = "instance_search_text_changed",
   VideoView = "video_view",
   VideoPercentageComplete = "video_percentage_complete",
+  VideoPlayback = "video_playback",
 }
 
 export const DebugLevelCustomPostHogEvents = [CustomPostHogEvents.MuteAudio, CustomPostHogEvents.UnmuteAudio];

--- a/OwnTube.tv/diagnostics/models.ts
+++ b/OwnTube.tv/diagnostics/models.ts
@@ -52,4 +52,14 @@ export type CustomPostHogEventParams = {
     totalFrames: number;
     droppedFramesPercent: number;
   };
+  [CustomPostHogEvents.VideoPlayback]: {
+    videoId: string;
+    currentTime: string;
+    isFullscreen: boolean;
+    externalPlaybackState?: "airplay" | "chromecast";
+    isMuted: boolean;
+    captionsEnabled: boolean;
+    captionsLanguage?: string;
+    viewEvent: "watch" | "seek";
+  };
 };

--- a/OwnTube.tv/package-lock.json
+++ b/OwnTube.tv/package-lock.json
@@ -65,7 +65,6 @@
         "react-native-screens": "~4.4.0",
         "react-native-svg": "^15.5.0",
         "react-native-toast-message": "^2.2.0",
-        "react-native-uuid": "^2.0.3",
         "react-native-video": "^6.16.1",
         "react-native-web": "~0.19.6",
         "react-qr-code": "^2.0.15",
@@ -16726,16 +16725,6 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
-      }
-    },
-    "node_modules/react-native-uuid": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/react-native-uuid/-/react-native-uuid-2.0.3.tgz",
-      "integrity": "sha512-f/YfIS2f5UB+gut7t/9BKGSCYbRA9/74A5R1MDp+FLYsuS+OSWoiM/D8Jko6OJB6Jcu3v6ONuddvZKHdIGpeiw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0",
-        "npm": ">=6.0.0"
       }
     },
     "node_modules/react-native-video": {

--- a/OwnTube.tv/package.json
+++ b/OwnTube.tv/package.json
@@ -69,7 +69,6 @@
     "react-native-screens": "~4.4.0",
     "react-native-svg": "^15.5.0",
     "react-native-toast-message": "^2.2.0",
-    "react-native-uuid": "^2.0.3",
     "react-native-video": "^6.16.1",
     "react-native-web": "~0.19.6",
     "react-qr-code": "^2.0.15",


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description
This PR adds additional diagnostics event for views, so that we log both to the PeerTube instance and to PostHog, while also making use of the `sessionId` given by PostHog, eliminating the need for creating our own uuids (thus the `react-native-uuid` package is removed)
<!-- Describe your changes in detail -->

## 📄 Motivation and Context
closes #438
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## 🧪 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

- [x] Web (desktop)
- [x] Web (mobile)
- [x] Mobile (iOS)
- [x] Mobile (Android)
- [x] TV (Android)
- [x] TV (Apple)

## 📦 Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist (copied from README)

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Squash your changes into a single clear and thoroughly descriptive commit, split changes into multiple commits only when it contributes to readability
- [x] Reference the GitHub issue that you are contributing on in your commit title or body
- [x] Sign your commits, as this is required by the automated GitHub PR checks
- [x] Ensure that the changes adhere to the project code style and formatting rules by running `npx eslint .` and `npx prettier --check ../` from the `./OwnTube.tv/` directory (without errors/warnings)
- [x] Include links and illustrations in your pull request to make it easy to review
- [x] Request a review by @mykhailodanilenko, @ar9708 and @mblomdahl
