### PR TITLE
Fix translation inconsistency: Change 'app URL' to 'web URL'

### DIFF
--- a/OwnTube.tv/locales/en.json
+++ b/OwnTube.tv/locales/en.json
@@ -56,7 +56,7 @@
   "shareVideoChannel": "Share channel URL in {{appName}}",
   "shareVideoChannelCategory": "Share channel category URL in {{appName}}",
   "sharePlaylist": "Share playlist URL in {{appName}}",
-  "shareAppURL": "Share app URL",
+  "shareAppURL": "Share web URL",
   "shareChannelPlaylist": "Share channel playlist",
   "qrCode": "QR code",
   "qrCodeForURL": "QR code for URL",

--- a/OwnTube.tv/locales/ru.json
+++ b/OwnTube.tv/locales/ru.json
@@ -56,7 +56,7 @@
   "shareVideoChannel": "Поделиться URL канала в {{appName}}",
   "shareVideoChannelCategory": "Поделиться URL категории на канале в {{appName}}",
   "sharePlaylist": "Поделиться URL плейлиста в {{appName}}",
-  "shareAppURL": "Поделиться URL приложения",
+  "shareAppURL": "Поделиться веб-URL",
   "shareChannelPlaylist": "Поделиться плейлистом канала",
   "qrCode": "QR-код",
   "qrCodeForURL": "QR-код для URL",

--- a/OwnTube.tv/locales/sv.json
+++ b/OwnTube.tv/locales/sv.json
@@ -56,7 +56,7 @@
   "shareVideoChannel": "Dela videokanal-URL i {{appName}}-appen",
   "shareVideoChannelCategory": "Dela kategori-URL i {{appName}}-appen",
   "sharePlaylist": "Dela URL till spellista i {{appName}}-appen",
-  "shareAppURL": "Dela app-URL",
+  "shareAppURL": "Dela webb-URL",
   "shareChannelPlaylist": "Dela spellista i videokanalen",
   "qrCode": "QR-kod",
   "qrCodeForURL": "QR-kod för URL",

--- a/OwnTube.tv/locales/uk.json
+++ b/OwnTube.tv/locales/uk.json
@@ -56,7 +56,7 @@
   "shareVideoChannel": "Поділитися URL каналу в {{appName}}",
   "shareVideoChannelCategory": "Поділитися URL категорії на канале в {{appName}}",
   "sharePlaylist": "Поділитися URL плейліста в {{appName}}",
-  "shareAppURL": "Поділитися URL додатку",
+  "shareAppURL": "Поділитися веб-URL",
   "shareChannelPlaylist": "Поділитися плейлістом каналу",
   "qrCode": "QR-код",
   "qrCodeForURL": "QR-код для URL",


### PR DESCRIPTION
Updated shareAppURL translation key across all language files to correctly reflect that the button shares web URLs rather than app-specific URLs.

- `en.json:` "Share app URL" → "Share web URL"
- `sv.json:` "Dela app-URL" → "Dela webb-URL"
- `uk.json:` "Поділитися URL додатку" → "Поділитися веб-URL"
- `ru.json:` "Поделиться URL приложения" → "Поделиться веб-URL"
