### PR TITLE
Improve Settings screen UI organization and translations

### DIFF
--- a/OwnTube.tv/components/DeviceCapabilities/DeviceCapabilities.tsx
+++ b/OwnTube.tv/components/DeviceCapabilities/DeviceCapabilities.tsx
@@ -79,7 +79,7 @@ const DeviceCapabilities = () => {
     <View style={{ backgroundColor: colors.theme50 }}>
       <View style={styles.modalHeader}>
         <Typography fontSize="sizeSm" fontWeight="SemiBold" color={colors.theme950}>
-          {t("deviceCapabilityInfoTitle")}
+          {t("settingsPageDeviceCapabilityInfoHeading")}
         </Typography>
         <Pressable onPress={handleCopyToClipboard} style={[styles.iconButton, { backgroundColor: colors.theme500 }]}>
           <IcoMoonIcon color={colors.white94} name="Content-Copy" size={24} />

--- a/OwnTube.tv/components/DeviceCapabilities/DeviceCapabilities.tv.tsx
+++ b/OwnTube.tv/components/DeviceCapabilities/DeviceCapabilities.tv.tsx
@@ -28,7 +28,7 @@ const DeviceCapabilities = () => {
     <View style={{ backgroundColor: colors.theme50 }}>
       <View style={styles.modalHeader}>
         <Typography fontSize="sizeSm" fontWeight="SemiBold" color={colors.theme950}>
-          {t("deviceCapabilityInfoTitle")}
+          {t("settingsPageDeviceCapabilityInfoHeading")}
         </Typography>
       </View>
       <View style={styles.capabilitiesContainer}>

--- a/OwnTube.tv/components/VideoContextMenu.tsx
+++ b/OwnTube.tv/components/VideoContextMenu.tsx
@@ -17,7 +17,11 @@ export const VideoContextMenu: React.FC<VideoContextMenuProps> = ({ handleOpenSe
 
   return (
     <TVFocusGuideHelper style={[styles.container, { borderColor: colors.white25, backgroundColor: colors.black80 }]}>
-      <Setting isSubmenuAvailable={false} onPress={handleOpenSettings} name={t("deviceCapabilityInfoTitle")} />
+      <Setting
+        isSubmenuAvailable={false}
+        onPress={handleOpenSettings}
+        name={t("settingsPageDeviceCapabilityInfoHeading")}
+      />
       {!!handleDownload && <Setting isSubmenuAvailable={false} onPress={handleDownload} name={t("downloadVideo")} />}
     </TVFocusGuideHelper>
   );

--- a/OwnTube.tv/components/VideoControlsOverlay/components/modals/Settings.tsx
+++ b/OwnTube.tv/components/VideoControlsOverlay/components/modals/Settings.tsx
@@ -74,11 +74,14 @@ export const Settings = ({ onClose }: SettingsProps) => {
         containerStyle={styles.modalContainer}
       >
         <ScrollView>
-          <Spacer height={spacing.sm} />
           <DeviceCapabilities />
-          <Spacer height={spacing.xl} />
+          <Spacer height={spacing.sm} />
           <Separator />
-          <Spacer height={spacing.xl} />
+          <Spacer height={spacing.sm} />
+          <Typography fontSize="sizeSm" fontWeight="SemiBold" color={colors.theme950}>
+            {t("settingsPageUiLanguageHeading")}
+          </Typography>
+          <Spacer height={spacing.sm} />
           <Picker
             darkTheme={isDarkTheme}
             placeholder={{}}
@@ -86,16 +89,25 @@ export const Settings = ({ onClose }: SettingsProps) => {
             onValueChange={handleSelectLanguage}
             items={LANGUAGE_OPTIONS}
           />
-          <Spacer height={spacing.xl} />
+          <Spacer height={spacing.sm} />
+          <Separator />
+          <Spacer height={spacing.sm} />
+          <Typography fontSize="sizeSm" fontWeight="SemiBold" color={colors.theme950}>
+            {t("settingsPageAppDiagnosticsHeading")}
+          </Typography>
+          <Spacer height={spacing.sm} />
           <Checkbox
             disabled={isOptedOut}
             checked={isDebugMode && !isOptedOut}
             onChange={handleToggleDebugMode}
-            label={t("debugLogging")}
+            label={t("settingsPageDebugLogging")}
           />
-          <Spacer height={spacing.md} />
-          <Checkbox checked={isOptedOut} onChange={handleToggleOptOutCheckbox} label={t("optOutOfDiagnostics")} />
-          <Spacer height={spacing.xl} />
+          <Checkbox
+            checked={isOptedOut}
+            onChange={handleToggleOptOutCheckbox}
+            label={t("settingsPageOptOutOfDiagnostics")}
+          />
+          <Spacer height={spacing.sm} />
           {!primaryBackend && (
             <>
               <Separator />

--- a/OwnTube.tv/locales/en.json
+++ b/OwnTube.tv/locales/en.json
@@ -5,11 +5,11 @@
   "viewVideo": "View video",
   "videoPageTitle": "Video",
   "error": "Error",
-  "debugLogging": "Debug logging for remote diagnostics",
+  "settingsPageDebugLogging": "Debug logging for remote diagnostics",
   "toggleTheme": "Toggle Theme",
   "revision": "Revision",
   "builtAtBy": "built at {{builtAt}} by",
-  "deviceCapabilityInfoTitle": "Client information",
+  "settingsPageDeviceCapabilityInfoHeading": "Client information",
   "playerImpl": "Player implementation:",
   "deviceType": "Device type:",
   "operatingSystem": "Operating system:",
@@ -181,5 +181,7 @@
   "_2faOn": "on",
   "sessionExpired": "expired",
   "sessionActive": "active",
-  "optOutOfDiagnostics": "Opt-out of sharing anonymized diagnostics"
+  "settingsPageOptOutOfDiagnostics": "Opt-out of sharing diagnostics",
+  "settingsPageUiLanguageHeading": "UI language",
+  "settingsPageAppDiagnosticsHeading": "App diagnostics"
 }

--- a/OwnTube.tv/locales/ru.json
+++ b/OwnTube.tv/locales/ru.json
@@ -5,11 +5,11 @@
   "viewVideo": "Просмотр видео",
   "videoPageTitle": "Видео",
   "error": "Ошибка",
-  "debugLogging": "Журнал отладки для удаленной диагностики",
+  "settingsPageDebugLogging": "Debug-логирование для удаленной диагностики",
   "toggleTheme": "Переключить тему",
   "revision": "Ревизия",
   "builtAtBy": "поставка от {{builtAt}} авторства",
-  "deviceCapabilityInfoTitle": "Информация о клиенте",
+  "settingsPageDeviceCapabilityInfoHeading": "Информация о клиенте",
   "playerImpl": "Реализация плеера:",
   "deviceType": "Тип устройства:",
   "operatingSystem": "Операционная система:",
@@ -180,5 +180,7 @@
   "_2faOff": "выключенной",
   "sessionExpired": "истекла",
   "sessionActive": "активна",
-  "optOutOfDiagnostics": "Отказ от обмена анонимной диагностикой"
+  "settingsPageOptOutOfDiagnostics": "Отключить обмен диагностикой",
+  "settingsPageUiLanguageHeading": "Язык интерфейса",
+  "settingsPageAppDiagnosticsHeading": "Диагностика приложения"
 }

--- a/OwnTube.tv/locales/sv.json
+++ b/OwnTube.tv/locales/sv.json
@@ -5,11 +5,11 @@
   "viewVideo": "Visa video",
   "videoPageTitle": "Video",
   "error": "Felmeddelande",
-  "debugLogging": "Felsökning av loggning för fjärrdiagnostik",
+  "settingsPageDebugLogging": "Debug-loggning i fjärrdiagnostik",
   "toggleTheme": "Växla tema",
   "revision": "Revision",
   "builtAtBy": "byggd {{builtAt}} av",
-  "deviceCapabilityInfoTitle": "Klient-information",
+  "settingsPageDeviceCapabilityInfoHeading": "Klient-information",
   "playerImpl": "Video-spelare:",
   "deviceType": "Typ av hårdvara:",
   "operatingSystem": "Operativsystem:",
@@ -181,5 +181,7 @@
   "sessionActive": "aktiv",
   "sessionExpired": "utgången",
   "currentAuthText": "Användare {{userName}} vid {{backend}}, med tvåfaktor {{_2fa}}, session startad {{sessionStartedAt}}, uppdaterad {{sessionUpdatedAt}}, {{expiredText}}, refresh token utfärdad {{refreshTokenIssuedAt}}",
-  "optOutOfDiagnostics": "Välja bort delning av anonymiserad diagnostik"
+  "settingsPageOptOutOfDiagnostics": "Inaktivera delning av diagnostik",
+  "settingsPageUiLanguageHeading": "Gränssnittsspråk",
+  "settingsPageAppDiagnosticsHeading": "App-diagnostik"
 }

--- a/OwnTube.tv/locales/uk.json
+++ b/OwnTube.tv/locales/uk.json
@@ -5,11 +5,11 @@
   "viewVideo": "Переглянути відео",
   "videoPageTitle": "Відео",
   "error": "Помилка",
-  "debugLogging": "Журнал налагодження для віддаленої діагностики",
+  "settingsPageDebugLogging": "Debug-логування для віддаленої діагностики",
   "toggleTheme": "Змінити тему",
   "revision": "Ревізія",
   "builtAtBy": "поставка від {{builtAt}} авторства",
-  "deviceCapabilityInfoTitle": "Інформація про клієнта",
+  "settingsPageDeviceCapabilityInfoHeading": "Інформація про клієнта",
   "playerImpl": "Реалізація плеєра:",
   "deviceType": "Тип пристрою:",
   "operatingSystem": "Операційна система:",
@@ -180,5 +180,7 @@
   "_2faOff": "вимкненою",
   "sessionExpired": "закінчилася",
   "sessionActive": "активна",
-  "optOutOfDiagnostics": "Відмова від обміну анонімізованою діагностикою"
+  "settingsPageOptOutOfDiagnostics": "Відключити обмін діагностикою",
+  "settingsPageUiLanguageHeading": "Мова інтерфейсу",
+  "settingsPageAppDiagnosticsHeading": "Діагностика додатку"
 }


### PR DESCRIPTION
- Add section headings for "UI language" and "App diagnostics" in Settings
- Reorganize Settings layout with proper separators and spacing
- Update translation keys for better organization (settingsPageDebugLogging, settingsPageOptOutOfDiagnostics, etc.)
- Simplify diagnostic text across all languages (remove "anonymized" qualifier)
- Make debug logging text more concise and consistent
- Update Swedish translations: "Debug-loggning i fjärrdiagnostik" and "Inaktivera delning av diagnostik"
