### PR TITLE
Fix alignment on settings auth info

### DIFF
--- a/OwnTube.tv/components/DeviceCapabilities/DeviceCapabilities.tsx
+++ b/OwnTube.tv/components/DeviceCapabilities/DeviceCapabilities.tsx
@@ -21,7 +21,7 @@ const CapabilityKeyValuePair = ({ label, value }: { label: string; value: string
       <Typography color={colors.themeDesaturated500} fontSize="sizeXS" fontWeight="Medium">
         {label}
       </Typography>
-      <Typography color={colors.themeDesaturated500} fontSize="sizeXS" fontWeight="Medium">
+      <Typography style={styles.row} color={colors.themeDesaturated500} fontSize="sizeXS" fontWeight="Medium">
         {value}
       </Typography>
     </View>
@@ -168,7 +168,7 @@ const styles = StyleSheet.create({
   capabilitiesContainer: {
     gap: 8,
   },
-  iconButton: { height: 36, paddingHorizontal: spacing.sm },
+  iconButton: { height: 36, paddingHorizontal: spacing.sm, paddingVertical: 6 },
   modalHeader: { flexDirection: "row", gap: 16, justifyContent: "space-between" },
   row: { flexWrap: "wrap", justifyContent: "space-between", width: "100%" },
 });


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description
This PR fixes the text wrapping on mobile platforms for auth info in the settings menu. See attached screenshots.
<!-- Describe your changes in detail -->

## 📄 Motivation and Context
#446
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## 🧪 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

- [x] Web (desktop)
- [x] Web (mobile)
- [x] Mobile (iOS)
- [x] Mobile (Android)
- [x] TV (Android)
- [x] TV (Apple)

## 📷 Screenshots (if appropriate)
<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-10-13 at 16 09 38" src="https://github.com/user-attachments/assets/3c68b750-6cb2-4ed4-8892-f46d2689b2a5" />

<!-- Please provide a screenshot of your change -->

## 📦 Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist (copied from README)

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Squash your changes into a single clear and thoroughly descriptive commit, split changes into multiple commits only when it contributes to readability
- [x] Reference the GitHub issue that you are contributing on in your commit title or body
- [x] Sign your commits, as this is required by the automated GitHub PR checks
- [x] Ensure that the changes adhere to the project code style and formatting rules by running `npx eslint .` and `npx prettier --check ../` from the `./OwnTube.tv/` directory (without errors/warnings)
- [x] Include links and illustrations in your pull request to make it easy to review
- [x] Request a review by @mykhailodanilenko, @ar9708 and @mblomdahl
