### PR TITLE
Pin Xcode to 16.4 and default macOS runner to macos-15

### DIFF
--- a/.github/workflows/build_ios_simulator_app.yml
+++ b/.github/workflows/build_ios_simulator_app.yml
@@ -13,7 +13,7 @@ on:
         description: "Should a parent repo be used for customizations? (Required for branded builds)"
       runner-label:
         type: string
-        default: "macos-latest"
+        default: "macos-15"
       customizations_env_content:
         required: false
         type: string
@@ -61,7 +61,7 @@ jobs:
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: latest-stable
+          xcode-version: 16.4
 
       - name: Build release .app for simulators by @${{ github.actor }}
         run: |

--- a/.github/workflows/build_tvos_simulator_app.yml
+++ b/.github/workflows/build_tvos_simulator_app.yml
@@ -13,7 +13,7 @@ on:
         description: "Should a parent repo be used for customizations? (Required for branded builds)"
       runner-label:
         type: string
-        default: "macos-latest"
+        default: "macos-15"
       customizations_env_content:
         required: false
         type: string
@@ -61,7 +61,7 @@ jobs:
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: latest-stable
+          xcode-version: 16.4
 
       - name: Build release tvOS .app for simulators by @${{ github.actor }}
         run: |

--- a/.github/workflows/deploy-static-main.yml
+++ b/.github/workflows/deploy-static-main.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Set macos runner
         id: set-macos-runner
         run: |
-          echo "runner-label=${{ vars.PREFERRED_MACOS_RUNNER || 'macos-latest' }}" >> $GITHUB_OUTPUT
+          echo "runner-label=${{ vars.PREFERRED_MACOS_RUNNER || 'macos-15' }}" >> $GITHUB_OUTPUT
 
   build_info:
     runs-on: ubuntu-latest

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -17,7 +17,7 @@ on:
         description: Upload iOS (iphoneos) or tvOS (appletvos) app
       runner-label:
         type: string
-        default: "macos-latest"
+        default: "macos-15"
       customizations_env_content:
         required: false
         type: string
@@ -135,7 +135,7 @@ jobs:
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: latest-stable
+          xcode-version: 16.4
 
       - name: Build and archive app for upload to Testflight by @${{ github.actor }}
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,6 +237,16 @@ Examples: `cust-app-blender`, `cust-app-xrtube`, `cust-app-basspistol`, `cust-ap
   - App Store Connect and Google Play accounts
   - Certificate/signing keys in GitHub Secrets
 
+### macOS Runner & Xcode Version
+
+iOS/tvOS build workflows pin both the macOS runner image and Xcode version to ensure compatibility with Expo SDK 52 / React Native 0.76:
+
+- **Xcode:** Pinned to `16.4` via `maxim-lobanov/setup-xcode@v1`. Do NOT use `latest-stable` — the `macos-15` runner now ships both Xcode 16.x and Xcode 26.3 RC, and `latest-stable` resolves to 26.x which is incompatible with React Native 0.76. Apple skipped versions 17–25 (jumped from 16 to 26).
+- **Runner:** `macos-15` (default in reusable workflow inputs). Do NOT use `macos-latest` — it resolves to macOS 26.
+- **Override:** The main repo can override the runner via `PREFERRED_MACOS_RUNNER` variable in the `owntube` environment. Downstream branded app repos use the default from the reusable workflow inputs.
+
+When upgrading Expo SDK or React Native, re-evaluate whether newer Xcode/runner versions are compatible and update the pins accordingly.
+
 ### Environments
 
 1. **`owntube` environment:** Stores sensitive secrets for app builds


### PR DESCRIPTION
## Summary
- Pin `xcode-version` from `latest-stable` back to `16.4` in all iOS/tvOS build workflows
- Change default `runner-label` from `macos-latest` to `macos-15` in reusable workflow inputs and `deploy-static-main.yml` fallback
- Document macOS runner and Xcode version constraints in CLAUDE.md

## Context
The `macos-15` runner now ships Xcode 26.3 RC alongside 16.x, and `latest-stable` resolves to 26.3 RC — which is incompatible with Expo SDK 52 / React Native 0.76 (Apple skipped versions 17–25). This broke all iOS/tvOS builds in downstream branded app repos despite `PREFERRED_MACOS_RUNNER` already being set to `macos-15`.

Build log from cust-app-xrtube confirming the issue: https://github.com/OwnTube-tv/cust-app-xrtube/actions/runs/22347211910/job/64664815299

Reverts the `latest-stable` change from #463. Fixes #485.

## Test plan
- [ ] Trigger iOS simulator build from a downstream branded app repo (e.g. cust-app-xrtube) and verify it completes successfully
- [ ] Verify `grep -r "latest-stable" .github/workflows/` returns no results
- [ ] Verify `grep -r "macos-latest" .github/workflows/` returns no results from iOS/tvOS/deploy workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)